### PR TITLE
Fix timeline display: move title out of circle marker

### DIFF
--- a/docs/superpowers/specs/2026-03-22-timeline-display-fix-design.md
+++ b/docs/superpowers/specs/2026-03-22-timeline-display-fix-design.md
@@ -1,0 +1,39 @@
+# Timeline Display Fix Design
+
+**Date:** 2026-03-22
+**Branch:** fix-timeline-display
+
+## Problem
+
+In `Timeline.tsx`, `todo.title` is rendered inside the 48×48px circular marker (`w-12 h-12`). Long titles are crammed into a tiny circle. The content area beside the circle only shows a formatted date.
+
+## Fix
+
+Single file change: `frontend/src/components/Timeline.tsx`
+
+1. **Inside the circle** — replace `<span className="text-white font-semibold">{todo.title}</span>` with a small white dot: `<div className="w-3 h-3 bg-white rounded-full" />`
+
+2. **In the content area** — add `<p className="text-sm text-gray-600">{todo.title}</p>` below the existing `<h3>` date line.
+
+## Result
+
+```
+Before:
+  [ Buy milk ]  ← title crammed in circle
+  Jan 15, 2024
+
+After:
+  [  •  ]  ← white dot in circle
+  Jan 15, 2024
+  Buy milk      ← title in content area
+```
+
+## Testing
+
+Existing `Timeline.test.tsx` tests still pass — title is still in the DOM, just in a `<p>` instead of a `<span>`. The `getByText('Release v1.0')` assertion remains valid. The count test uses `{ selector: 'span' }` — since titles move to `<p>`, this selector no longer matches titles. The count test must be updated to use `{ selector: 'p' }`.
+
+## Scope
+
+- Modify: `frontend/src/components/Timeline.tsx`
+- Update: `frontend/src/components/Timeline.test.tsx` (fix selector in count test)
+- No other files change

--- a/frontend/src/components/Timeline.test.tsx
+++ b/frontend/src/components/Timeline.test.tsx
@@ -22,9 +22,9 @@ describe('TimelineComponent', () => {
   test('renders correct number of timeline entries for each todo in the passed array', () => {
     const todos = [makeTodo(1, 'Event A'), makeTodo(2, 'Event B'), makeTodo(3, 'Event C')];
     render(<TimelineComponent todos={todos} />);
-    // Each entry renders the title once (inside the circular marker)
-    // Use selector: 'span' to avoid matching both the span and its parent div (which has the same text content)
-    expect(screen.getAllByText(/Event [ABC]/, { selector: 'span' })).toHaveLength(3);
+    // Each entry renders the title once (below the date in the content area)
+    // Use selector: 'p' to avoid matching parent elements with the same text content
+    expect(screen.getAllByText(/Event [ABC]/, { selector: 'p' })).toHaveLength(3);
   });
 
   test('renders todo titles in the timeline', () => {

--- a/frontend/src/components/Timeline.tsx
+++ b/frontend/src/components/Timeline.tsx
@@ -13,12 +13,13 @@ const TimelineComponent: React.FC<TimelineProps> = ({ todos }) => {
         {todos.map((todo, index) => (
           <div key={index} className="flex items-start mb-8">
             {/* Timeline marker */}
-            <div className="w-12 h-12 bg-blue-500 rounded-full flex items-center justify-center">
-              <span className="text-white font-semibold">{todo.title}</span>
+            <div className="w-12 h-12 bg-blue-500 rounded-full flex items-center justify-center flex-shrink-0">
+              <div className="w-3 h-3 bg-white rounded-full" />
             </div>
             {/* Event details */}
             <div className="ml-4">
               <h3 className="text-lg font-bold mb-1">{new Date(todo.created_at).toLocaleDateString()}</h3>
+              <p className="text-sm text-gray-600">{todo.title}</p>
             </div>
           </div>
         ))}


### PR DESCRIPTION
## Summary
- The todo title was crammed into the 48×48px circular marker, making it unreadable
- Circle now shows a white dot bullet instead
- Title renders below the date in the content area beside the circle
- Updated `Timeline.test.tsx` selector from `span` to `p` to match new markup

## Test Plan
- [ ] All frontend tests pass
- [ ] Add a todo with type "Timeline" and verify title displays correctly beside the circle

🤖 Generated with [Claude Code](https://claude.com/claude-code)