### PR TITLE
feat: add JWT-based authentication with per-user todo scoping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ dist/
 # Misc
 *.swp
 *.swo
+
+# Git worktrees
+.worktrees/

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -1,0 +1,61 @@
+from datetime import datetime, timezone, timedelta
+import jwt
+from jwt.exceptions import InvalidTokenError
+from passlib.context import CryptContext
+from fastapi import Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer
+from sqlalchemy.ext.asyncio import AsyncConnection
+
+from database import users, get_db_conn
+from settings import settings
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/login")
+
+
+def hash_password(plain: str) -> str:
+    return pwd_context.hash(plain)
+
+
+def verify_password(plain: str, hashed: str) -> bool:
+    return pwd_context.verify(plain, hashed)
+
+
+def create_access_token(data: dict) -> str:
+    payload = data.copy()
+    payload["exp"] = datetime.now(timezone.utc) + timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
+    return jwt.encode(payload, settings.SECRET_KEY, algorithm="HS256")
+
+
+def decode_access_token(token: str) -> dict:
+    try:
+        return jwt.decode(token, settings.SECRET_KEY, algorithms=["HS256"])
+    except InvalidTokenError:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or expired token",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+
+async def get_current_user(
+    token: str = Depends(oauth2_scheme),
+    conn: AsyncConnection = Depends(get_db_conn),
+):
+    payload = decode_access_token(token)
+    username = payload.get("sub")
+    if not username:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid token payload",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    result = await conn.execute(users.select().where(users.c.username == username))
+    user = result.mappings().first()
+    if not user:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="User not found",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    return user

--- a/backend/database.py
+++ b/backend/database.py
@@ -7,6 +7,8 @@ from sqlalchemy import (
     String,
     Boolean,
     DateTime,
+    ForeignKey,
+    text,
 )
 from sqlalchemy.ext.asyncio import create_async_engine, AsyncConnection
 from datetime import datetime, timezone
@@ -14,6 +16,15 @@ from settings import settings
 
 engine = create_async_engine(settings.DATABASE_URL)
 metadata = MetaData()
+
+users = Table(
+    "users",
+    metadata,
+    Column("id", Integer, primary_key=True),
+    Column("username", String, unique=True, nullable=False),
+    Column("hashed_password", String, nullable=False),
+    Column("created_at", DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False),
+)
 
 todos = Table(
     "todos",
@@ -24,7 +35,9 @@ todos = Table(
     Column("created_at", DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False),
     Column("updated_at", DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc), nullable=False),
     Column("type", String, default="todo", nullable=False),
+    Column("user_id", Integer, ForeignKey("users.id"), nullable=False),
 )
+
 
 async def get_db_conn() -> AsyncGenerator[AsyncConnection, None]:
     async with engine.connect() as connection:
@@ -33,4 +46,9 @@ async def get_db_conn() -> AsyncGenerator[AsyncConnection, None]:
 
 async def create_db_and_tables():
     async with engine.begin() as conn:
+        # create_all creates users first (no deps), then todos (depends on users)
         await conn.run_sync(metadata.create_all)
+        # Add user_id to todos on existing DBs — safe no-op if column already exists
+        await conn.execute(
+            text("ALTER TABLE todos ADD COLUMN IF NOT EXISTS user_id INTEGER NOT NULL REFERENCES users(id)")
+        )

--- a/backend/database.py
+++ b/backend/database.py
@@ -1,3 +1,4 @@
+from typing import AsyncGenerator
 from sqlalchemy import (
     MetaData,
     Table,
@@ -7,7 +8,7 @@ from sqlalchemy import (
     Boolean,
     DateTime,
 )
-from sqlalchemy.ext.asyncio import create_async_engine
+from sqlalchemy.ext.asyncio import create_async_engine, AsyncConnection
 from datetime import datetime, timezone
 from settings import settings
 
@@ -24,6 +25,11 @@ todos = Table(
     Column("updated_at", DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc), nullable=False),
     Column("type", String, default="todo", nullable=False),
 )
+
+async def get_db_conn() -> AsyncGenerator[AsyncConnection, None]:
+    async with engine.connect() as connection:
+        yield connection
+
 
 async def create_db_and_tables():
     async with engine.begin() as conn:

--- a/backend/main.py
+++ b/backend/main.py
@@ -4,10 +4,9 @@ from typing import List
 from datetime import datetime, timezone
 from contextlib import asynccontextmanager
 
-from sqlalchemy.ext.asyncio import AsyncConnection
-
 from models import Todo, TodoCreate, TodoUpdate
-from database import engine, todos, create_db_and_tables
+from database import engine, todos, create_db_and_tables, get_db_conn
+from sqlalchemy.ext.asyncio import AsyncConnection
 
 
 @asynccontextmanager
@@ -25,11 +24,6 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
-
-
-async def get_db_conn() -> AsyncConnection:
-    async with engine.connect() as connection:
-        yield connection
 
 
 @app.get("/")

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,12 +1,15 @@
 from fastapi import FastAPI, HTTPException, Depends
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.security import OAuth2PasswordRequestForm
 from typing import List
 from datetime import datetime, timezone
 from contextlib import asynccontextmanager
 
-from models import Todo, TodoCreate, TodoUpdate
-from database import engine, todos, create_db_and_tables, get_db_conn
 from sqlalchemy.ext.asyncio import AsyncConnection
+
+from models import Todo, TodoCreate, TodoUpdate, UserCreate, Token
+from database import engine, todos, users, create_db_and_tables, get_db_conn
+from auth import get_current_user, hash_password, verify_password, create_access_token
 
 
 @asynccontextmanager
@@ -31,14 +34,43 @@ async def root():
     return {"message": "Todo API is running"}
 
 
+@app.post("/auth/register", response_model=Token, status_code=201)
+async def register(user_create: UserCreate, conn: AsyncConnection = Depends(get_db_conn)):
+    result = await conn.execute(users.select().where(users.c.username == user_create.username))
+    if result.mappings().first():
+        raise HTTPException(status_code=409, detail="Username already taken")
+    hashed = hash_password(user_create.password)
+    await conn.execute(users.insert().values(username=user_create.username, hashed_password=hashed))
+    await conn.commit()
+    return Token(access_token=create_access_token({"sub": user_create.username}))
+
+
+@app.post("/auth/login", response_model=Token)
+async def login(form: OAuth2PasswordRequestForm = Depends(), conn: AsyncConnection = Depends(get_db_conn)):
+    result = await conn.execute(users.select().where(users.c.username == form.username))
+    user = result.mappings().first()
+    if not user or not verify_password(form.password, user["hashed_password"]):
+        raise HTTPException(
+            status_code=401,
+            detail="Invalid credentials",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    return Token(access_token=create_access_token({"sub": user["username"]}))
+
+
 @app.get("/todos", response_model=List[Todo])
-async def get_todos(conn: AsyncConnection = Depends(get_db_conn)):
-    result = await conn.execute(todos.select())
+async def get_todos(
+    current_user=Depends(get_current_user),
+    conn: AsyncConnection = Depends(get_db_conn),
+):
+    result = await conn.execute(todos.select().where(todos.c.user_id == current_user["id"]))
     return result.mappings().all()
 
 
-async def get_todo_by_id(todo_id: int, conn: AsyncConnection):
-    result = await conn.execute(todos.select().where(todos.c.id == todo_id))
+async def get_todo_by_id(todo_id: int, user_id: int, conn: AsyncConnection):
+    result = await conn.execute(
+        todos.select().where(todos.c.id == todo_id).where(todos.c.user_id == user_id)
+    )
     todo = result.mappings().first()
     if not todo:
         raise HTTPException(status_code=404, detail="Todo not found")
@@ -46,39 +78,61 @@ async def get_todo_by_id(todo_id: int, conn: AsyncConnection):
 
 
 @app.get("/todos/{todo_id}", response_model=Todo)
-async def get_todo(todo_id: int, conn: AsyncConnection = Depends(get_db_conn)):
-    return await get_todo_by_id(todo_id, conn)
+async def get_todo(
+    todo_id: int,
+    current_user=Depends(get_current_user),
+    conn: AsyncConnection = Depends(get_db_conn),
+):
+    return await get_todo_by_id(todo_id, current_user["id"], conn)
 
 
 @app.post("/todos", response_model=Todo, status_code=201)
-async def create_todo(todo_create: TodoCreate, conn: AsyncConnection = Depends(get_db_conn)):
+async def create_todo(
+    todo_create: TodoCreate,
+    current_user=Depends(get_current_user),
+    conn: AsyncConnection = Depends(get_db_conn),
+):
     now = datetime.now(timezone.utc)
     todo_type = todo_create.type if todo_create.type else "todo"
     query = todos.insert().values(
-        title=todo_create.title, completed=False, created_at=now, updated_at=now, type=todo_type
+        title=todo_create.title,
+        completed=False,
+        created_at=now,
+        updated_at=now,
+        type=todo_type,
+        user_id=current_user["id"],
     )
     result = await conn.execute(query)
     await conn.commit()
     new_id = result.inserted_primary_key[0]
-    return await get_todo_by_id(new_id, conn)
+    return await get_todo_by_id(new_id, current_user["id"], conn)
 
 
 @app.put("/todos/{todo_id}", response_model=Todo)
-async def update_todo(todo_id: int, todo_update: TodoUpdate, conn: AsyncConnection = Depends(get_db_conn)):
+async def update_todo(
+    todo_id: int,
+    todo_update: TodoUpdate,
+    current_user=Depends(get_current_user),
+    conn: AsyncConnection = Depends(get_db_conn),
+):
     now = datetime.now(timezone.utc)
     update_data = todo_update.model_dump(exclude_unset=True)
     update_data["updated_at"] = now
-    query = todos.update().where(todos.c.id == todo_id).values(**update_data)
+    query = todos.update().where(todos.c.id == todo_id).where(todos.c.user_id == current_user["id"]).values(**update_data)
     result = await conn.execute(query)
     await conn.commit()
     if result.rowcount == 0:
         raise HTTPException(status_code=404, detail="Todo not found")
-    return await get_todo_by_id(todo_id, conn)
+    return await get_todo_by_id(todo_id, current_user["id"], conn)
 
 
 @app.delete("/todos/{todo_id}", status_code=204)
-async def delete_todo(todo_id: int, conn: AsyncConnection = Depends(get_db_conn)):
-    query = todos.delete().where(todos.c.id == todo_id)
+async def delete_todo(
+    todo_id: int,
+    current_user=Depends(get_current_user),
+    conn: AsyncConnection = Depends(get_db_conn),
+):
+    query = todos.delete().where(todos.c.id == todo_id).where(todos.c.user_id == current_user["id"])
     result = await conn.execute(query)
     await conn.commit()
     if result.rowcount == 0:

--- a/backend/models.py
+++ b/backend/models.py
@@ -2,6 +2,7 @@ from pydantic import BaseModel, field_validator, ConfigDict
 from typing import Optional
 from datetime import datetime
 
+
 class TodoCreate(BaseModel):
     title: str
     type: Optional[str] = "todo"
@@ -13,9 +14,11 @@ class TodoCreate(BaseModel):
             raise ValueError('Title must not be empty')
         return v
 
+
 class TodoUpdate(BaseModel):
     title: Optional[str] = None
     completed: Optional[bool] = None
+
 
 class Todo(BaseModel):
     id: int
@@ -26,3 +29,27 @@ class Todo(BaseModel):
     type: str
 
     model_config = ConfigDict(from_attributes=True)
+
+
+class UserCreate(BaseModel):
+    username: str
+    password: str
+
+    @field_validator('password')
+    @classmethod
+    def password_min_length(cls, v):
+        if len(v) < 8:
+            raise ValueError('Password must be at least 8 characters')
+        return v
+
+
+class UserPublic(BaseModel):
+    id: int
+    username: str
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class Token(BaseModel):
+    access_token: str
+    token_type: str = "bearer"

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,3 +9,4 @@ pydantic-settings==2.2.1
 SQLAlchemy==2.0.29
 PyJWT==2.8.0
 passlib[bcrypt]==1.7.4
+bcrypt==4.0.1

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,3 +7,5 @@ httpx==0.24.1
 asyncpg==0.29.0
 pydantic-settings==2.2.1
 SQLAlchemy==2.0.29
+PyJWT==2.8.0
+passlib[bcrypt]==1.7.4

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -4,5 +4,7 @@ class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_file='.env', env_file_encoding='utf-8')
 
     DATABASE_URL: str = "postgresql+asyncpg://user:password@localhost/tododb"
+    SECRET_KEY: str
+    ACCESS_TOKEN_EXPIRE_MINUTES: int = 30
 
 settings = Settings()

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,0 +1,104 @@
+import asyncio
+import pytest
+import main as main_module
+import database as database_module
+from fastapi.testclient import TestClient
+from sqlalchemy import text
+from sqlalchemy.pool import NullPool
+from sqlalchemy.ext.asyncio import create_async_engine
+from database import metadata
+from settings import settings
+from main import app
+from auth import get_current_user
+
+# NullPool engine for auth tests. Both this and test_endpoints.py's engine use
+# the same DATABASE_URL + NullPool — functionally equivalent, last import wins
+# the module-level patch but both point to the same DB so tests work correctly.
+test_engine_auth = create_async_engine(settings.DATABASE_URL, poolclass=NullPool)
+
+database_module.engine = test_engine_auth
+main_module.engine = test_engine_auth
+
+client = TestClient(app)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def create_tables_auth():
+    async def setup():
+        async with test_engine_auth.begin() as conn:
+            await conn.run_sync(metadata.create_all)
+    asyncio.run(setup())
+
+
+@pytest.fixture(autouse=True)
+def reset_auth_state():
+    # Auth tests use real get_current_user — remove only the endpoint test mock, nothing else
+    app.dependency_overrides.pop(get_current_user, None)
+    async def truncate():
+        async with test_engine_auth.begin() as conn:
+            await conn.execute(text("TRUNCATE TABLE todos, users RESTART IDENTITY CASCADE"))
+    asyncio.run(truncate())
+    yield
+    app.dependency_overrides.pop(get_current_user, None)
+
+
+class TestRegister:
+    def test_register_returns_token(self):
+        response = client.post("/auth/register", json={"username": "alice", "password": "password123"})
+        assert response.status_code == 201
+        data = response.json()
+        assert "access_token" in data
+        assert data["token_type"] == "bearer"
+
+    def test_register_duplicate_username_returns_409(self):
+        client.post("/auth/register", json={"username": "alice", "password": "password123"})
+        response = client.post("/auth/register", json={"username": "alice", "password": "password123"})
+        assert response.status_code == 409
+
+    def test_register_short_password_returns_422(self):
+        response = client.post("/auth/register", json={"username": "alice", "password": "short"})
+        assert response.status_code == 422
+
+
+class TestLogin:
+    def test_login_returns_token(self):
+        client.post("/auth/register", json={"username": "alice", "password": "password123"})
+        response = client.post("/auth/login", data={"username": "alice", "password": "password123"})
+        assert response.status_code == 200
+        assert "access_token" in response.json()
+
+    def test_login_wrong_password_returns_401(self):
+        client.post("/auth/register", json={"username": "alice", "password": "password123"})
+        response = client.post("/auth/login", data={"username": "alice", "password": "wrongpassword"})
+        assert response.status_code == 401
+
+    def test_login_unknown_user_returns_401(self):
+        response = client.post("/auth/login", data={"username": "nobody", "password": "password123"})
+        assert response.status_code == 401
+
+
+class TestTodosRequireAuth:
+    def test_get_todos_without_token_returns_401(self):
+        response = client.get("/todos")
+        assert response.status_code == 401
+
+    def test_get_todos_returns_only_current_user_todos(self):
+        # Register two users
+        r1 = client.post("/auth/register", json={"username": "alice", "password": "password123"})
+        token_alice = r1.json()["access_token"]
+        r2 = client.post("/auth/register", json={"username": "bob", "password": "password123"})
+        token_bob = r2.json()["access_token"]
+
+        # Alice creates a todo
+        client.post("/todos", json={"title": "Alice's todo"},
+                    headers={"Authorization": f"Bearer {token_alice}"})
+
+        # Bob sees empty list
+        response = client.get("/todos", headers={"Authorization": f"Bearer {token_bob}"})
+        assert response.status_code == 200
+        assert response.json() == []
+
+        # Alice sees her todo
+        response = client.get("/todos", headers={"Authorization": f"Bearer {token_alice}"})
+        assert len(response.json()) == 1
+        assert response.json()[0]["title"] == "Alice's todo"

--- a/backend/tests/test_endpoints.py
+++ b/backend/tests/test_endpoints.py
@@ -1,4 +1,5 @@
 import asyncio
+from datetime import datetime, timezone
 import pytest
 import main as main_module
 import database as database_module
@@ -9,22 +10,27 @@ from sqlalchemy.ext.asyncio import create_async_engine
 from database import metadata
 from settings import settings
 from main import app
+from auth import get_current_user
 
 # Test-only engine: NullPool avoids asyncpg pool-per-event-loop issues
-# when asyncio.run() is called repeatedly from sync pytest fixtures.
 test_engine = create_async_engine(settings.DATABASE_URL, poolclass=NullPool)
 
-# Patch both the database module and main module engine references to use NullPool
-# so that asyncpg connections are not reused across different event loops.
 database_module.engine = test_engine
 main_module.engine = test_engine
+
+TEST_USER = {"id": 1, "username": "testuser", "hashed_password": "x", "created_at": datetime.now(timezone.utc)}
+
+
+async def mock_get_current_user():
+    return TEST_USER
+
 
 client = TestClient(app)
 
 
 @pytest.fixture(scope="session", autouse=True)
 def create_tables():
-    """Create the todos table once before any test runs."""
+    """Create all tables once before any test runs."""
     async def setup():
         async with test_engine.begin() as conn:
             await conn.run_sync(metadata.create_all)
@@ -33,12 +39,18 @@ def create_tables():
 
 @pytest.fixture(autouse=True)
 def reset_state():
-    """Truncate todos table before each test for isolation."""
-    async def truncate():
+    """Set dependency override, truncate todos + users (CASCADE), re-insert test user."""
+    # Set override per-test so it doesn't bleed into test_auth.py
+    app.dependency_overrides[get_current_user] = mock_get_current_user
+    async def setup():
         async with test_engine.begin() as conn:
-            await conn.execute(text("TRUNCATE TABLE todos RESTART IDENTITY"))
-    asyncio.run(truncate())
+            await conn.execute(text("TRUNCATE TABLE todos, users RESTART IDENTITY CASCADE"))
+            await conn.execute(
+                text("INSERT INTO users (id, username, hashed_password, created_at) VALUES (1, 'testuser', 'x', NOW())")
+            )
+    asyncio.run(setup())
     yield
+    app.dependency_overrides.pop(get_current_user, None)
 
 
 class TestHealthCheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,10 @@
 services:
   postgres:
     image: postgres:13
-    container_name: todo-postgres
     environment:
       - POSTGRES_USER=user
       - POSTGRES_PASSWORD=password
       - POSTGRES_DB=tododb
-    ports:
-      - "5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
@@ -20,7 +17,6 @@ services:
   backend:
     build:
       context: ./backend
-    container_name: todo-backend
     ports:
       - "8000:8000"
     volumes:
@@ -29,6 +25,7 @@ services:
       - PYTHONUNBUFFERED=1
       - PYTHONPATH=/app
       - DATABASE_URL=postgresql+asyncpg://user:password@postgres/tododb
+      - SECRET_KEY=dev-secret-key-change-in-production
     depends_on:
       postgres:
         condition: service_healthy
@@ -38,7 +35,6 @@ services:
     build:
       context: ./frontend
       target: development
-    container_name: todo-frontend
     ports:
       - "3000:3000"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
       - POSTGRES_DB=tododb
     volumes:
       - postgres_data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U user -d tododb"]
       interval: 5s

--- a/docs/superpowers/plans/2026-03-23-auth.md
+++ b/docs/superpowers/plans/2026-03-23-auth.md
@@ -1,0 +1,1663 @@
+# Basic Authentication Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add JWT-based registration/login with per-user todo scoping — every `/todos` endpoint requires a valid Bearer token, todos are isolated per user.
+
+**Architecture:** Backend-first: infrastructure changes → DB schema → auth utilities → endpoints → tests. Frontend after all backend tests pass. Backend uses `PyJWT` + `passlib[bcrypt]`; `get_db_conn` moves from `main.py` to `database.py` to avoid a circular import (`auth.py` needs `get_db_conn`, `main.py` needs `auth.py`).
+
+**Tech Stack:** FastAPI, SQLAlchemy Core (async), asyncpg, PyJWT, passlib[bcrypt], React, TypeScript.
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|---|---|---|
+| `backend/requirements.txt` | Modify | Add PyJWT, passlib |
+| `backend/settings.py` | Modify | Add SECRET_KEY, ACCESS_TOKEN_EXPIRE_MINUTES |
+| `backend/database.py` | Modify | Move get_db_conn here; add users table, user_id FK on todos, migration |
+| `backend/auth.py` | Create | hash_password, verify_password, create_access_token, decode_access_token, get_current_user |
+| `backend/models.py` | Modify | Add UserCreate (with password validator), UserPublic, Token |
+| `backend/main.py` | Modify | Import get_db_conn from database; add /auth/register, /auth/login; protect /todos |
+| `backend/tests/test_auth.py` | Create | Auth endpoint integration tests |
+| `backend/tests/test_endpoints.py` | Modify | Truncate users CASCADE; override get_current_user with test user |
+| `docker-compose.yml` | Modify | Add SECRET_KEY env var |
+| `frontend/src/services/auth.ts` | Create | register(), login() — returns token string |
+| `frontend/src/services/api.ts` | Modify | Add token param + Authorization header; onUnauthorized callback on 401 |
+| `frontend/src/components/AuthForm.tsx` | Create | Login/register toggle form |
+| `frontend/src/App.tsx` | Modify | Token state, auth gate, logout, 401→re-login |
+| `frontend/src/services/api.test.ts` | Modify | Update tests to pass token, verify Authorization header |
+| `frontend/src/components/AuthForm.test.tsx` | Create | AuthForm unit tests |
+| `frontend/src/App.test.tsx` | Modify | Mock auth module, simulate login for existing tests |
+
+---
+
+## Task 1: Add dependencies, settings, move get_db_conn
+
+**Files:**
+- Modify: `backend/requirements.txt`
+- Modify: `backend/settings.py`
+- Modify: `backend/database.py`
+- Modify: `backend/main.py`
+- Modify: `docker-compose.yml`
+
+- [ ] **Step 1: Add new Python packages to requirements.txt**
+
+Append two lines to `backend/requirements.txt`:
+
+```
+PyJWT==2.8.0
+passlib[bcrypt]==1.7.4
+```
+
+- [ ] **Step 2: Add SECRET_KEY and ACCESS_TOKEN_EXPIRE_MINUTES to settings.py**
+
+Replace `backend/settings.py` with:
+
+```python
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+class Settings(BaseSettings):
+    model_config = SettingsConfigDict(env_file='.env', env_file_encoding='utf-8')
+
+    DATABASE_URL: str = "postgresql+asyncpg://user:password@localhost/tododb"
+    SECRET_KEY: str
+    ACCESS_TOKEN_EXPIRE_MINUTES: int = 30
+
+settings = Settings()
+```
+
+`SECRET_KEY` has no default — startup fails loudly if not set.
+
+- [ ] **Step 3: Move get_db_conn to database.py**
+
+Replace `backend/database.py` with:
+
+```python
+from sqlalchemy import (
+    MetaData,
+    Table,
+    Column,
+    Integer,
+    String,
+    Boolean,
+    DateTime,
+)
+from sqlalchemy.ext.asyncio import create_async_engine, AsyncConnection
+from datetime import datetime, timezone
+from settings import settings
+
+engine = create_async_engine(settings.DATABASE_URL)
+metadata = MetaData()
+
+todos = Table(
+    "todos",
+    metadata,
+    Column("id", Integer, primary_key=True),
+    Column("title", String, nullable=False),
+    Column("completed", Boolean, default=False, nullable=False),
+    Column("created_at", DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False),
+    Column("updated_at", DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc), nullable=False),
+    Column("type", String, default="todo", nullable=False),
+)
+
+
+async def get_db_conn() -> AsyncConnection:
+    async with engine.connect() as connection:
+        yield connection
+
+
+async def create_db_and_tables():
+    async with engine.begin() as conn:
+        await conn.run_sync(metadata.create_all)
+```
+
+- [ ] **Step 4: Update main.py to import get_db_conn from database**
+
+In `backend/main.py`, change line 10:
+
+Old:
+```python
+from database import engine, todos, create_db_and_tables
+```
+
+New:
+```python
+from database import engine, todos, create_db_and_tables, get_db_conn
+```
+
+And remove the `get_db_conn` function definition (lines 30–32):
+
+```python
+async def get_db_conn() -> AsyncConnection:
+    async with engine.connect() as connection:
+        yield connection
+```
+
+Also remove the `AsyncConnection` import from `main.py` — it's no longer used there. The import block in `main.py` should become:
+
+```python
+from fastapi import FastAPI, HTTPException, Depends
+from fastapi.middleware.cors import CORSMiddleware
+from typing import List
+from datetime import datetime, timezone
+from contextlib import asynccontextmanager
+
+from models import Todo, TodoCreate, TodoUpdate
+from database import engine, todos, create_db_and_tables, get_db_conn
+```
+
+- [ ] **Step 5: Add SECRET_KEY to docker-compose.yml backend environment**
+
+In `docker-compose.yml`, add to the backend `environment` block:
+
+```yaml
+      - SECRET_KEY=dev-secret-key-change-in-production
+```
+
+- [ ] **Step 6: Verify imports work**
+
+```bash
+docker compose run --rm backend python -c "from database import get_db_conn; from settings import settings; print('SECRET_KEY set:', bool(settings.SECRET_KEY))"
+```
+
+Expected: `SECRET_KEY set: True`
+
+- [ ] **Step 7: Run existing tests to confirm nothing broke**
+
+```bash
+docker compose run --rm backend python -m pytest tests/ -v
+```
+
+Expected: 22 passed.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add backend/requirements.txt backend/settings.py backend/database.py backend/main.py docker-compose.yml
+git commit -m "feat: add auth deps/settings, move get_db_conn to database.py"
+```
+
+---
+
+## Task 2: DB schema — users table + user_id migration
+
+**Files:**
+- Modify: `backend/database.py`
+
+- [ ] **Step 1: Add users table and user_id FK to database.py**
+
+Replace `backend/database.py` with:
+
+```python
+from sqlalchemy import (
+    MetaData,
+    Table,
+    Column,
+    Integer,
+    String,
+    Boolean,
+    DateTime,
+    ForeignKey,
+    text,
+)
+from sqlalchemy.ext.asyncio import create_async_engine, AsyncConnection
+from datetime import datetime, timezone
+from settings import settings
+
+engine = create_async_engine(settings.DATABASE_URL)
+metadata = MetaData()
+
+users = Table(
+    "users",
+    metadata,
+    Column("id", Integer, primary_key=True),
+    Column("username", String, unique=True, nullable=False),
+    Column("hashed_password", String, nullable=False),
+    Column("created_at", DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False),
+)
+
+todos = Table(
+    "todos",
+    metadata,
+    Column("id", Integer, primary_key=True),
+    Column("title", String, nullable=False),
+    Column("completed", Boolean, default=False, nullable=False),
+    Column("created_at", DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False),
+    Column("updated_at", DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc), nullable=False),
+    Column("type", String, default="todo", nullable=False),
+    Column("user_id", Integer, ForeignKey("users.id"), nullable=False),
+)
+
+
+async def get_db_conn() -> AsyncConnection:
+    async with engine.connect() as connection:
+        yield connection
+
+
+async def create_db_and_tables():
+    async with engine.begin() as conn:
+        # create_all creates users first (no deps), then todos (depends on users)
+        await conn.run_sync(metadata.create_all)
+        # Add user_id to todos on existing DBs — safe no-op if column already exists
+        await conn.execute(
+            text("ALTER TABLE todos ADD COLUMN IF NOT EXISTS user_id INTEGER NOT NULL REFERENCES users(id)")
+        )
+```
+
+- [ ] **Step 2: Reset the database volume (required — existing todos have no user_id)**
+
+```bash
+docker compose down -v
+docker compose up -d postgres
+```
+
+Wait ~5 seconds for Postgres to be healthy.
+
+- [ ] **Step 3: Verify tables are created correctly**
+
+```bash
+docker compose run --rm backend python -c "
+import asyncio
+from database import create_db_and_tables
+asyncio.run(create_db_and_tables())
+print('Tables created OK')
+"
+```
+
+Expected: `Tables created OK` with no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/database.py
+git commit -m "feat: add users table and user_id FK to todos schema"
+```
+
+---
+
+## Task 3: Create auth.py — password hashing + JWT
+
+**Files:**
+- Create: `backend/auth.py`
+
+- [ ] **Step 1: Write the failing import test**
+
+```bash
+docker compose run --rm backend python -c "import jwt; import passlib; print('deps ok')"
+```
+
+Expected: `deps ok`. If it fails, the new packages aren't installed yet — rebuild: `docker compose build backend`.
+
+- [ ] **Step 2: Create backend/auth.py**
+
+```python
+from datetime import datetime, timezone, timedelta
+import jwt
+from jwt.exceptions import InvalidTokenError
+from passlib.context import CryptContext
+from fastapi import Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer
+from sqlalchemy.ext.asyncio import AsyncConnection
+
+from database import users, get_db_conn
+from settings import settings
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/login")
+
+
+def hash_password(plain: str) -> str:
+    return pwd_context.hash(plain)
+
+
+def verify_password(plain: str, hashed: str) -> bool:
+    return pwd_context.verify(plain, hashed)
+
+
+def create_access_token(data: dict) -> str:
+    payload = data.copy()
+    payload["exp"] = datetime.now(timezone.utc) + timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
+    return jwt.encode(payload, settings.SECRET_KEY, algorithm="HS256")
+
+
+def decode_access_token(token: str) -> dict:
+    try:
+        return jwt.decode(token, settings.SECRET_KEY, algorithms=["HS256"])
+    except InvalidTokenError:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or expired token",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+
+async def get_current_user(
+    token: str = Depends(oauth2_scheme),
+    conn: AsyncConnection = Depends(get_db_conn),
+):
+    payload = decode_access_token(token)
+    username = payload.get("sub")
+    if not username:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid token payload",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    result = await conn.execute(users.select().where(users.c.username == username))
+    user = result.mappings().first()
+    if not user:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="User not found",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    return user
+```
+
+- [ ] **Step 3: Verify auth.py imports cleanly**
+
+```bash
+docker compose run --rm backend python -c "from auth import hash_password, verify_password, create_access_token, decode_access_token; print('auth.py OK')"
+```
+
+Expected: `auth.py OK`
+
+- [ ] **Step 4: Verify password hashing and JWT round-trip**
+
+```bash
+docker compose run --rm backend python -c "
+from auth import hash_password, verify_password, create_access_token, decode_access_token
+h = hash_password('mypassword')
+assert verify_password('mypassword', h), 'verify failed'
+assert not verify_password('wrong', h), 'should fail'
+token = create_access_token({'sub': 'alice'})
+payload = decode_access_token(token)
+assert payload['sub'] == 'alice', 'sub mismatch'
+print('All checks passed')
+"
+```
+
+Expected: `All checks passed`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/auth.py
+git commit -m "feat: add auth.py — password hashing and JWT utilities"
+```
+
+---
+
+## Task 4: Add auth Pydantic models
+
+**Files:**
+- Modify: `backend/models.py`
+
+- [ ] **Step 1: Add UserCreate, UserPublic, Token to models.py**
+
+Replace `backend/models.py` with:
+
+```python
+from pydantic import BaseModel, field_validator, ConfigDict
+from typing import Optional
+from datetime import datetime
+
+
+class TodoCreate(BaseModel):
+    title: str
+    type: Optional[str] = "todo"
+
+    @field_validator('title')
+    @classmethod
+    def title_must_not_be_empty(cls, v):
+        if not v or not v.strip():
+            raise ValueError('Title must not be empty')
+        return v
+
+
+class TodoUpdate(BaseModel):
+    title: Optional[str] = None
+    completed: Optional[bool] = None
+
+
+class Todo(BaseModel):
+    id: int
+    title: str
+    completed: bool
+    created_at: datetime
+    updated_at: datetime
+    type: str
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class UserCreate(BaseModel):
+    username: str
+    password: str
+
+    @field_validator('password')
+    @classmethod
+    def password_min_length(cls, v):
+        if len(v) < 8:
+            raise ValueError('Password must be at least 8 characters')
+        return v
+
+
+class UserPublic(BaseModel):
+    id: int
+    username: str
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class Token(BaseModel):
+    access_token: str
+    token_type: str = "bearer"
+```
+
+- [ ] **Step 2: Verify models import cleanly**
+
+```bash
+docker compose run --rm backend python -c "from models import UserCreate, Token; print('models OK')"
+```
+
+Expected: `models OK`
+
+- [ ] **Step 3: Run all backend tests**
+
+```bash
+docker compose run --rm backend python -m pytest tests/ -v
+```
+
+Expected: all passing (test_main.py model tests now cover new models implicitly; test_endpoints.py still passes).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/models.py
+git commit -m "feat: add UserCreate, UserPublic, Token Pydantic models"
+```
+
+---
+
+## Task 5: Add auth endpoints and protect /todos
+
+**Files:**
+- Modify: `backend/main.py`
+
+- [ ] **Step 1: Replace backend/main.py**
+
+```python
+from fastapi import FastAPI, HTTPException, Depends
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.security import OAuth2PasswordRequestForm
+from typing import List
+from datetime import datetime, timezone
+from contextlib import asynccontextmanager
+
+from sqlalchemy.ext.asyncio import AsyncConnection
+
+from models import Todo, TodoCreate, TodoUpdate, UserCreate, Token
+from database import engine, todos, users, create_db_and_tables, get_db_conn
+from auth import get_current_user, hash_password, verify_password, create_access_token
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    await create_db_and_tables()
+    yield
+
+
+app = FastAPI(title="Todo API", version="1.0.0", lifespan=lifespan)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["http://localhost:3000"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+@app.get("/")
+async def root():
+    return {"message": "Todo API is running"}
+
+
+@app.post("/auth/register", response_model=Token, status_code=201)
+async def register(user_create: UserCreate, conn: AsyncConnection = Depends(get_db_conn)):
+    result = await conn.execute(users.select().where(users.c.username == user_create.username))
+    if result.mappings().first():
+        raise HTTPException(status_code=409, detail="Username already taken")
+    hashed = hash_password(user_create.password)
+    await conn.execute(users.insert().values(username=user_create.username, hashed_password=hashed))
+    await conn.commit()
+    return Token(access_token=create_access_token({"sub": user_create.username}))
+
+
+@app.post("/auth/login", response_model=Token)
+async def login(form: OAuth2PasswordRequestForm = Depends(), conn: AsyncConnection = Depends(get_db_conn)):
+    result = await conn.execute(users.select().where(users.c.username == form.username))
+    user = result.mappings().first()
+    if not user or not verify_password(form.password, user["hashed_password"]):
+        raise HTTPException(
+            status_code=401,
+            detail="Invalid credentials",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    return Token(access_token=create_access_token({"sub": user["username"]}))
+
+
+@app.get("/todos", response_model=List[Todo])
+async def get_todos(
+    current_user=Depends(get_current_user),
+    conn: AsyncConnection = Depends(get_db_conn),
+):
+    result = await conn.execute(todos.select().where(todos.c.user_id == current_user["id"]))
+    return result.mappings().all()
+
+
+async def get_todo_by_id(todo_id: int, user_id: int, conn: AsyncConnection):
+    result = await conn.execute(
+        todos.select().where(todos.c.id == todo_id).where(todos.c.user_id == user_id)
+    )
+    todo = result.mappings().first()
+    if not todo:
+        raise HTTPException(status_code=404, detail="Todo not found")
+    return todo
+
+
+@app.get("/todos/{todo_id}", response_model=Todo)
+async def get_todo(
+    todo_id: int,
+    current_user=Depends(get_current_user),
+    conn: AsyncConnection = Depends(get_db_conn),
+):
+    return await get_todo_by_id(todo_id, current_user["id"], conn)
+
+
+@app.post("/todos", response_model=Todo, status_code=201)
+async def create_todo(
+    todo_create: TodoCreate,
+    current_user=Depends(get_current_user),
+    conn: AsyncConnection = Depends(get_db_conn),
+):
+    now = datetime.now(timezone.utc)
+    todo_type = todo_create.type if todo_create.type else "todo"
+    query = todos.insert().values(
+        title=todo_create.title,
+        completed=False,
+        created_at=now,
+        updated_at=now,
+        type=todo_type,
+        user_id=current_user["id"],
+    )
+    result = await conn.execute(query)
+    await conn.commit()
+    new_id = result.inserted_primary_key[0]
+    return await get_todo_by_id(new_id, current_user["id"], conn)
+
+
+@app.put("/todos/{todo_id}", response_model=Todo)
+async def update_todo(
+    todo_id: int,
+    todo_update: TodoUpdate,
+    current_user=Depends(get_current_user),
+    conn: AsyncConnection = Depends(get_db_conn),
+):
+    now = datetime.now(timezone.utc)
+    update_data = todo_update.model_dump(exclude_unset=True)
+    update_data["updated_at"] = now
+    query = todos.update().where(todos.c.id == todo_id).where(todos.c.user_id == current_user["id"]).values(**update_data)
+    result = await conn.execute(query)
+    await conn.commit()
+    if result.rowcount == 0:
+        raise HTTPException(status_code=404, detail="Todo not found")
+    return await get_todo_by_id(todo_id, current_user["id"], conn)
+
+
+@app.delete("/todos/{todo_id}", status_code=204)
+async def delete_todo(
+    todo_id: int,
+    current_user=Depends(get_current_user),
+    conn: AsyncConnection = Depends(get_db_conn),
+):
+    query = todos.delete().where(todos.c.id == todo_id).where(todos.c.user_id == current_user["id"])
+    result = await conn.execute(query)
+    await conn.commit()
+    if result.rowcount == 0:
+        raise HTTPException(status_code=404, detail="Todo not found")
+    return
+
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run("main:app", host="0.0.0.0", port=8000, reload=True)
+```
+
+- [ ] **Step 2: Smoke test the app starts**
+
+```bash
+docker compose run --rm backend python -c "from main import app; print('main.py OK')"
+```
+
+Expected: `main.py OK`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/main.py
+git commit -m "feat: add /auth/register, /auth/login; protect /todos with JWT auth"
+```
+
+---
+
+## Task 6: Update test infrastructure + write test_auth.py
+
+**Files:**
+- Modify: `backend/tests/test_endpoints.py`
+- Create: `backend/tests/test_auth.py`
+
+The existing endpoint tests need two changes:
+1. `reset_state` must truncate `users` too (CASCADE handles FK order)
+2. `get_current_user` dependency is overridden to return a hardcoded test user (no JWT needed for CRUD tests)
+3. A test user row is inserted before each test so FK constraint on `todos.user_id` is satisfied
+
+**Design note — intentional deviation from spec:** The spec proposes a `user_token` fixture that registers a test user, obtains a real JWT, and passes it via a function-scoped `TestClient` fixture. This plan uses `app.dependency_overrides` instead, keeping `client` as a module-level `TestClient(app)`. Rationale: endpoint tests verify CRUD behavior, not auth. Bypassing `get_current_user` entirely keeps these tests fast, simple, and focused. Real JWT auth is covered by `test_auth.py`. A module-level `client` is correct for this approach because `TestClient` captures no auth state — FastAPI resolves `app.dependency_overrides` at request dispatch time, so the per-test override in `reset_state` is active for every request. The override is set and torn down per-test (inside `reset_state`), so it doesn't bleed into auth tests.
+
+- [ ] **Step 1: Replace backend/tests/test_endpoints.py**
+
+```python
+import asyncio
+from datetime import datetime, timezone
+import pytest
+import main as main_module
+import database as database_module
+from fastapi.testclient import TestClient
+from sqlalchemy import text
+from sqlalchemy.pool import NullPool
+from sqlalchemy.ext.asyncio import create_async_engine
+from database import metadata
+from settings import settings
+from main import app
+from auth import get_current_user
+
+# Test-only engine: NullPool avoids asyncpg pool-per-event-loop issues
+test_engine = create_async_engine(settings.DATABASE_URL, poolclass=NullPool)
+
+database_module.engine = test_engine
+main_module.engine = test_engine
+
+TEST_USER = {"id": 1, "username": "testuser", "hashed_password": "x", "created_at": datetime.now(timezone.utc)}
+
+
+async def mock_get_current_user():
+    return TEST_USER
+
+
+client = TestClient(app)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def create_tables():
+    """Create all tables once before any test runs."""
+    async def setup():
+        async with test_engine.begin() as conn:
+            await conn.run_sync(metadata.create_all)
+    asyncio.run(setup())
+
+
+@pytest.fixture(autouse=True)
+def reset_state():
+    """Set dependency override, truncate todos + users (CASCADE), re-insert test user."""
+    # Set override per-test so it doesn't bleed into test_auth.py
+    app.dependency_overrides[get_current_user] = mock_get_current_user
+    async def setup():
+        async with test_engine.begin() as conn:
+            await conn.execute(text("TRUNCATE TABLE todos, users RESTART IDENTITY CASCADE"))
+            await conn.execute(
+                text("INSERT INTO users (id, username, hashed_password) VALUES (1, 'testuser', 'x')")
+            )
+    asyncio.run(setup())
+    yield
+    app.dependency_overrides.pop(get_current_user, None)
+
+
+class TestHealthCheck:
+    def test_root_returns_200(self):
+        response = client.get("/")
+        assert response.status_code == 200
+
+
+class TestGetTodos:
+    def test_returns_empty_list_initially(self):
+        response = client.get("/todos")
+        assert response.status_code == 200
+        assert response.json() == []
+
+    def test_returns_todos_after_creation(self):
+        client.post("/todos", json={"title": "Task A"})
+        response = client.get("/todos")
+        assert response.status_code == 200
+        assert len(response.json()) == 1
+        assert response.json()[0]["title"] == "Task A"
+
+
+class TestCreateTodo:
+    def test_creates_todo_with_default_type(self):
+        response = client.post("/todos", json={"title": "My task"})
+        assert response.status_code == 201
+        data = response.json()
+        assert data["title"] == "My task"
+        assert data["type"] == "todo"
+        assert data["completed"] is False
+
+    def test_creates_todo_with_explicit_timeline_type(self):
+        response = client.post("/todos", json={"title": "Milestone", "type": "timeline"})
+        assert response.status_code == 201
+        assert response.json()["type"] == "timeline"
+
+    def test_returns_422_for_missing_title(self):
+        response = client.post("/todos", json={})
+        assert response.status_code == 422
+
+
+class TestGetTodoById:
+    def test_returns_correct_todo(self):
+        created = client.post("/todos", json={"title": "Find me"}).json()
+        response = client.get(f"/todos/{created['id']}")
+        assert response.status_code == 200
+        assert response.json()["title"] == "Find me"
+
+    def test_returns_404_for_unknown_id(self):
+        response = client.get("/todos/9999")
+        assert response.status_code == 404
+
+
+class TestUpdateTodo:
+    def test_updates_completed_status(self):
+        created = client.post("/todos", json={"title": "Toggle me"}).json()
+        response = client.put(f"/todos/{created['id']}", json={"completed": True})
+        assert response.status_code == 200
+        assert response.json()["completed"] is True
+
+    def test_updates_title(self):
+        created = client.post("/todos", json={"title": "Old title"}).json()
+        response = client.put(f"/todos/{created['id']}", json={"title": "New title"})
+        assert response.status_code == 200
+        assert response.json()["title"] == "New title"
+
+    def test_returns_404_for_unknown_id(self):
+        response = client.put("/todos/9999", json={"completed": True})
+        assert response.status_code == 404
+
+
+class TestDeleteTodo:
+    def test_deletes_todo_successfully(self):
+        created = client.post("/todos", json={"title": "Delete me"}).json()
+        response = client.delete(f"/todos/{created['id']}")
+        assert response.status_code == 204
+        assert client.get(f"/todos/{created['id']}").status_code == 404
+
+    def test_returns_404_for_unknown_id(self):
+        response = client.delete("/todos/9999")
+        assert response.status_code == 404
+```
+
+- [ ] **Step 2: Create backend/tests/test_auth.py**
+
+```python
+import asyncio
+import pytest
+import main as main_module
+import database as database_module
+from fastapi.testclient import TestClient
+from sqlalchemy import text
+from sqlalchemy.pool import NullPool
+from sqlalchemy.ext.asyncio import create_async_engine
+from database import metadata
+from settings import settings
+from main import app
+from auth import get_current_user
+
+# NullPool engine for auth tests. Both this and test_endpoints.py's engine use
+# the same DATABASE_URL + NullPool — functionally equivalent, last import wins
+# the module-level patch but both point to the same DB so tests work correctly.
+test_engine_auth = create_async_engine(settings.DATABASE_URL, poolclass=NullPool)
+
+database_module.engine = test_engine_auth
+main_module.engine = test_engine_auth
+
+client = TestClient(app)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def create_tables_auth():
+    async def setup():
+        async with test_engine_auth.begin() as conn:
+            await conn.run_sync(metadata.create_all)
+    asyncio.run(setup())
+
+
+@pytest.fixture(autouse=True)
+def reset_auth_state():
+    # Auth tests use real get_current_user — remove only the endpoint test mock, nothing else
+    app.dependency_overrides.pop(get_current_user, None)
+    async def truncate():
+        async with test_engine_auth.begin() as conn:
+            await conn.execute(text("TRUNCATE TABLE todos, users RESTART IDENTITY CASCADE"))
+    asyncio.run(truncate())
+    yield
+    app.dependency_overrides.pop(get_current_user, None)
+
+
+class TestRegister:
+    def test_register_returns_token(self):
+        response = client.post("/auth/register", json={"username": "alice", "password": "password123"})
+        assert response.status_code == 201
+        data = response.json()
+        assert "access_token" in data
+        assert data["token_type"] == "bearer"
+
+    def test_register_duplicate_username_returns_409(self):
+        client.post("/auth/register", json={"username": "alice", "password": "password123"})
+        response = client.post("/auth/register", json={"username": "alice", "password": "password123"})
+        assert response.status_code == 409
+
+    def test_register_short_password_returns_422(self):
+        response = client.post("/auth/register", json={"username": "alice", "password": "short"})
+        assert response.status_code == 422
+
+
+class TestLogin:
+    def test_login_returns_token(self):
+        client.post("/auth/register", json={"username": "alice", "password": "password123"})
+        response = client.post("/auth/login", data={"username": "alice", "password": "password123"})
+        assert response.status_code == 200
+        assert "access_token" in response.json()
+
+    def test_login_wrong_password_returns_401(self):
+        client.post("/auth/register", json={"username": "alice", "password": "password123"})
+        response = client.post("/auth/login", data={"username": "alice", "password": "wrongpassword"})
+        assert response.status_code == 401
+
+    def test_login_unknown_user_returns_401(self):
+        response = client.post("/auth/login", data={"username": "nobody", "password": "password123"})
+        assert response.status_code == 401
+
+
+class TestTodosRequireAuth:
+    def test_get_todos_without_token_returns_401(self):
+        response = client.get("/todos")
+        assert response.status_code == 401
+
+    def test_get_todos_returns_only_current_user_todos(self):
+        # Register two users
+        r1 = client.post("/auth/register", json={"username": "alice", "password": "password123"})
+        token_alice = r1.json()["access_token"]
+        r2 = client.post("/auth/register", json={"username": "bob", "password": "password123"})
+        token_bob = r2.json()["access_token"]
+
+        # Alice creates a todo
+        client.post("/todos", json={"title": "Alice's todo"},
+                    headers={"Authorization": f"Bearer {token_alice}"})
+
+        # Bob sees empty list
+        response = client.get("/todos", headers={"Authorization": f"Bearer {token_bob}"})
+        assert response.status_code == 200
+        assert response.json() == []
+
+        # Alice sees her todo
+        response = client.get("/todos", headers={"Authorization": f"Bearer {token_alice}"})
+        assert len(response.json()) == 1
+        assert response.json()[0]["title"] == "Alice's todo"
+```
+
+- [ ] **Step 3: Run all backend tests**
+
+```bash
+docker compose run --rm backend python -m pytest tests/ -v
+```
+
+Expected: all tests pass (test_main.py + test_endpoints.py + test_auth.py).
+
+Note: if `test_auth.py` and `test_endpoints.py` conflict on the `database_module.engine` patch, run them in separate invocations first:
+
+```bash
+docker compose run --rm backend python -m pytest tests/test_endpoints.py -v
+docker compose run --rm backend python -m pytest tests/test_auth.py -v
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/tests/test_endpoints.py backend/tests/test_auth.py
+git commit -m "test: update test_endpoints fixture for auth; add test_auth.py"
+```
+
+---
+
+## Task 7: Frontend — auth.ts + update api.ts
+
+**Files:**
+- Create: `frontend/src/services/auth.ts`
+- Modify: `frontend/src/services/api.ts`
+- Modify: `frontend/src/services/api.test.ts`
+
+- [ ] **Step 1: Create frontend/src/services/auth.ts**
+
+```typescript
+const API_URL = 'http://127.0.0.1:8000';
+
+export const register = async (username: string, password: string): Promise<string> => {
+  const response = await fetch(`${API_URL}/auth/register`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username, password }),
+  });
+  if (!response.ok) {
+    const error = await response.json();
+    throw new Error(error.detail || 'Registration failed');
+  }
+  const data = await response.json();
+  return data.access_token;
+};
+
+export const login = async (username: string, password: string): Promise<string> => {
+  const body = new URLSearchParams({ username, password });
+  const response = await fetch(`${API_URL}/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: body.toString(),
+  });
+  if (!response.ok) {
+    const error = await response.json();
+    throw new Error(error.detail || 'Login failed');
+  }
+  const data = await response.json();
+  return data.access_token;
+};
+```
+
+- [ ] **Step 2: Replace frontend/src/services/api.ts**
+
+```typescript
+import { Todo } from '../types/todo';
+
+const API_URL = 'http://127.0.0.1:8000';
+
+const authHeaders = (token: string) => ({
+  'Authorization': `Bearer ${token}`,
+});
+
+export const getTodos = async (token: string, onUnauthorized?: () => void): Promise<Todo[]> => {
+  const response = await fetch(`${API_URL}/todos`, {
+    headers: authHeaders(token),
+  });
+  if (response.status === 401) {
+    onUnauthorized?.();
+    throw new Error('Failed to fetch todos');
+  }
+  if (!response.ok) {
+    throw new Error('Failed to fetch todos');
+  }
+  return await response.json();
+};
+
+export const addTodo = async (text: string, token: string, onUnauthorized?: () => void): Promise<Todo> => {
+  const response = await fetch(`${API_URL}/todos`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...authHeaders(token) },
+    body: JSON.stringify({ title: text }),
+  });
+  if (response.status === 401) {
+    onUnauthorized?.();
+    throw new Error('Failed to add todo');
+  }
+  if (!response.ok) {
+    throw new Error('Failed to add todo');
+  }
+  return await response.json();
+};
+
+export const updateTodo = async (
+  id: number,
+  updatedFields: Partial<Pick<Todo, 'title' | 'completed'>>,
+  token: string,
+  onUnauthorized?: () => void,
+): Promise<Todo> => {
+  const response = await fetch(`${API_URL}/todos/${id}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json', ...authHeaders(token) },
+    body: JSON.stringify(updatedFields),
+  });
+  if (response.status === 401) {
+    onUnauthorized?.();
+    throw new Error('Failed to update todo');
+  }
+  if (!response.ok) {
+    throw new Error('Failed to update todo');
+  }
+  return await response.json();
+};
+
+export const deleteTodo = async (id: number, token: string, onUnauthorized?: () => void): Promise<void> => {
+  const response = await fetch(`${API_URL}/todos/${id}`, {
+    method: 'DELETE',
+    headers: authHeaders(token),
+  });
+  if (response.status === 401) {
+    onUnauthorized?.();
+    throw new Error('Failed to delete todo');
+  }
+  if (!response.ok) {
+    throw new Error('Failed to delete todo');
+  }
+};
+```
+
+- [ ] **Step 3: Replace frontend/src/services/api.test.ts**
+
+```typescript
+import { getTodos, addTodo, updateTodo, deleteTodo } from './api';
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+const mockTodo = {
+  id: 1,
+  title: 'Test',
+  completed: false,
+  created_at: '2024-01-01T00:00:00Z',
+  updated_at: '2024-01-01T00:00:00Z',
+  type: 'todo',
+};
+
+const TOKEN = 'test-token';
+const AUTH_HEADER = { Authorization: `Bearer ${TOKEN}` };
+
+beforeEach(() => mockFetch.mockClear());
+
+describe('getTodos', () => {
+  test('calls GET /todos with Authorization header and returns parsed JSON', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true, status: 200, json: async () => [mockTodo] });
+    const result = await getTodos(TOKEN);
+    expect(mockFetch).toHaveBeenCalledWith('http://127.0.0.1:8000/todos', {
+      headers: AUTH_HEADER,
+    });
+    expect(result).toEqual([mockTodo]);
+  });
+
+  test('calls onUnauthorized and throws on 401', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 401 });
+    const onUnauthorized = jest.fn();
+    await expect(getTodos(TOKEN, onUnauthorized)).rejects.toThrow('Failed to fetch todos');
+    expect(onUnauthorized).toHaveBeenCalled();
+  });
+
+  test('throws on non-ok response', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 500 });
+    await expect(getTodos(TOKEN)).rejects.toThrow('Failed to fetch todos');
+  });
+});
+
+describe('addTodo', () => {
+  test('calls POST /todos with Authorization header and returns created todo', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true, status: 201, json: async () => mockTodo });
+    const result = await addTodo('Test', TOKEN);
+    expect(mockFetch).toHaveBeenCalledWith('http://127.0.0.1:8000/todos', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...AUTH_HEADER },
+      body: JSON.stringify({ title: 'Test' }),
+    });
+    expect(result).toEqual(mockTodo);
+  });
+
+  test('throws on non-ok response', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 500 });
+    await expect(addTodo('Test', TOKEN)).rejects.toThrow('Failed to add todo');
+  });
+});
+
+describe('updateTodo', () => {
+  test('calls PUT /todos/{id} with Authorization header and returns updated todo', async () => {
+    const updated = { ...mockTodo, completed: true };
+    mockFetch.mockResolvedValueOnce({ ok: true, status: 200, json: async () => updated });
+    const result = await updateTodo(1, { completed: true }, TOKEN);
+    expect(mockFetch).toHaveBeenCalledWith('http://127.0.0.1:8000/todos/1', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json', ...AUTH_HEADER },
+      body: JSON.stringify({ completed: true }),
+    });
+    expect(result).toEqual(updated);
+  });
+
+  test('throws on non-ok response', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 500 });
+    await expect(updateTodo(1, { completed: true }, TOKEN)).rejects.toThrow('Failed to update todo');
+  });
+});
+
+describe('deleteTodo', () => {
+  test('calls DELETE /todos/{id} with Authorization header', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true, status: 204 });
+    await deleteTodo(1, TOKEN);
+    expect(mockFetch).toHaveBeenCalledWith('http://127.0.0.1:8000/todos/1', {
+      method: 'DELETE',
+      headers: AUTH_HEADER,
+    });
+  });
+
+  test('calls onUnauthorized and throws on 401', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 401 });
+    const onUnauthorized = jest.fn();
+    await expect(deleteTodo(1, TOKEN, onUnauthorized)).rejects.toThrow('Failed to delete todo');
+    expect(onUnauthorized).toHaveBeenCalled();
+  });
+
+  test('throws on non-ok response', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 500 });
+    await expect(deleteTodo(1, TOKEN)).rejects.toThrow('Failed to delete todo');
+  });
+});
+```
+
+- [ ] **Step 4: Run frontend tests**
+
+```bash
+cd frontend && npm test -- --watchAll=false --testPathPattern="api.test"
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/services/auth.ts frontend/src/services/api.ts frontend/src/services/api.test.ts
+git commit -m "feat: add auth.ts; update api.ts with token param and Authorization header"
+```
+
+---
+
+## Task 8: AuthForm component + tests
+
+**Files:**
+- Create: `frontend/src/components/AuthForm.tsx`
+- Create: `frontend/src/components/AuthForm.test.tsx`
+
+- [ ] **Step 1: Create frontend/src/components/AuthForm.tsx**
+
+```tsx
+import React, { useState } from 'react';
+import { login, register } from '../services/auth';
+
+interface AuthFormProps {
+  onAuth: (token: string) => void;
+}
+
+const AuthForm: React.FC<AuthFormProps> = ({ onAuth }) => {
+  const [mode, setMode] = useState<'login' | 'register'>('login');
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setLoading(true);
+    try {
+      const token = mode === 'login'
+        ? await login(username, password)
+        : await register(username, password);
+      onAuth(token);
+    } catch (err: any) {
+      setError(err.message || 'Something went wrong');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="auth-container">
+      <h2>{mode === 'login' ? 'Log In' : 'Register'}</h2>
+      <form onSubmit={handleSubmit}>
+        <input
+          type="text"
+          placeholder="Username"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+          required
+        />
+        <input
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+        />
+        <button type="submit" disabled={loading}>
+          {loading ? 'Loading...' : mode === 'login' ? 'Log In' : 'Register'}
+        </button>
+      </form>
+      {error && <p style={{ color: 'red' }}>{error}</p>}
+      <button
+        type="button"
+        onClick={() => { setMode(mode === 'login' ? 'register' : 'login'); setError(null); }}
+      >
+        {mode === 'login' ? 'Switch to Register' : 'Switch to Login'}
+      </button>
+    </div>
+  );
+};
+
+export default AuthForm;
+```
+
+- [ ] **Step 2: Create frontend/src/components/AuthForm.test.tsx**
+
+```tsx
+import React from 'react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import AuthForm from './AuthForm';
+import * as auth from '../services/auth';
+
+jest.mock('../services/auth');
+
+describe('AuthForm', () => {
+  const onAuth = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('renders login mode by default', () => {
+    render(<AuthForm onAuth={onAuth} />);
+    expect(screen.getByRole('heading', { name: /log in/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /log in/i })).toBeInTheDocument();
+  });
+
+  test('switches to register mode when toggle is clicked', () => {
+    render(<AuthForm onAuth={onAuth} />);
+    fireEvent.click(screen.getByRole('button', { name: /switch to register/i }));
+    expect(screen.getByRole('heading', { name: /register/i })).toBeInTheDocument();
+  });
+
+  test('calls onAuth with token on successful login', async () => {
+    (auth.login as jest.Mock).mockResolvedValueOnce('my-token');
+    render(<AuthForm onAuth={onAuth} />);
+    fireEvent.change(screen.getByPlaceholderText('Username'), { target: { value: 'alice' } });
+    fireEvent.change(screen.getByPlaceholderText('Password'), { target: { value: 'password123' } });
+    await act(async () => {
+      fireEvent.submit(screen.getByRole('button', { name: /log in/i }).closest('form')!);
+    });
+    await waitFor(() => expect(onAuth).toHaveBeenCalledWith('my-token'));
+  });
+
+  test('shows error message on failed login', async () => {
+    (auth.login as jest.Mock).mockRejectedValueOnce(new Error('Invalid credentials'));
+    render(<AuthForm onAuth={onAuth} />);
+    fireEvent.change(screen.getByPlaceholderText('Username'), { target: { value: 'alice' } });
+    fireEvent.change(screen.getByPlaceholderText('Password'), { target: { value: 'wrongpass' } });
+    await act(async () => {
+      fireEvent.submit(screen.getByRole('button', { name: /log in/i }).closest('form')!);
+    });
+    await waitFor(() => expect(screen.getByText('Invalid credentials')).toBeInTheDocument());
+    expect(onAuth).not.toHaveBeenCalled();
+  });
+
+  test('calls onAuth with token on successful register', async () => {
+    (auth.register as jest.Mock).mockResolvedValueOnce('reg-token');
+    render(<AuthForm onAuth={onAuth} />);
+    fireEvent.click(screen.getByRole('button', { name: /switch to register/i }));
+    fireEvent.change(screen.getByPlaceholderText('Username'), { target: { value: 'alice' } });
+    fireEvent.change(screen.getByPlaceholderText('Password'), { target: { value: 'password123' } });
+    await act(async () => {
+      fireEvent.submit(screen.getByRole('button', { name: /register/i }).closest('form')!);
+    });
+    await waitFor(() => expect(onAuth).toHaveBeenCalledWith('reg-token'));
+  });
+});
+```
+
+- [ ] **Step 3: Run frontend tests**
+
+```bash
+cd frontend && npm test -- --watchAll=false --testPathPattern="AuthForm.test"
+```
+
+Expected: all 5 tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/components/AuthForm.tsx frontend/src/components/AuthForm.test.tsx
+git commit -m "feat: add AuthForm component with login/register toggle"
+```
+
+---
+
+## Task 9: Update App.tsx + App.test.tsx
+
+**Files:**
+- Modify: `frontend/src/App.tsx`
+- Modify: `frontend/src/App.test.tsx`
+
+- [ ] **Step 1: Replace frontend/src/App.tsx**
+
+```tsx
+import React, { useState, useEffect } from 'react';
+import { Todo } from './types/todo';
+import TodoList from './components/TodoList';
+import TodoForm from './components/TodoForm';
+import AuthForm from './components/AuthForm';
+import * as api from './services/api';
+import TimelineComponent from './components/Timeline';
+import { Tab, Tabs, TabList, TabPanel } from 'react-tabs';
+import 'react-tabs/style/react-tabs.css';
+import './App.css';
+
+const App: React.FC = () => {
+  const [token, setToken] = useState<string | null>(null);
+  const [todos, setTodos] = useState<Todo[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleUnauthorized = () => setToken(null);
+
+  useEffect(() => {
+    if (token) fetchTodos();
+  }, [token]);
+
+  const fetchTodos = async () => {
+    if (!token) return;
+    try {
+      setLoading(true);
+      const data = await api.getTodos(token, handleUnauthorized);
+      setTodos(data);
+    } catch (err) {
+      setError('Failed to fetch todos.');
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const addTodo = async (text: string) => {
+    if (!token) return;
+    try {
+      const newTodo = await api.addTodo(text, token, handleUnauthorized);
+      setTodos((prevTodos) => [...prevTodos, newTodo]);
+    } catch (err) {
+      setError('Failed to add todo.');
+      console.error(err);
+    }
+  };
+
+  const toggleComplete = async (id: number) => {
+    if (!token) return;
+    const todoToUpdate = todos.find(todo => todo.id === id);
+    if (!todoToUpdate) return;
+    const updatedTodo = { ...todoToUpdate, completed: !todoToUpdate.completed };
+    try {
+      await api.updateTodo(id, updatedTodo, token, handleUnauthorized);
+      setTodos((prevTodos) =>
+        prevTodos.map((todo) => (todo.id === id ? updatedTodo : todo))
+      );
+    } catch (err) {
+      setError('Failed to update todo.');
+      console.error(err);
+    }
+  };
+
+  const deleteTodo = async (id: number) => {
+    if (!token) return;
+    try {
+      await api.deleteTodo(id, token, handleUnauthorized);
+      setTodos((prevTodos) => prevTodos.filter((todo) => todo.id !== id));
+    } catch (err) {
+      setError('Failed to delete todo.');
+      console.error(err);
+    }
+  };
+
+  if (!token) {
+    return <AuthForm onAuth={setToken} />;
+  }
+
+  if (loading) {
+    return <div>Loading...</div>;
+  }
+
+  if (error) {
+    return <div style={{ color: 'red' }}>Error: {error}</div>;
+  }
+
+  const timelineEnabled = process.env.REACT_APP_TIMELINE_FEATURE_FLAG === 'true';
+  const todoItems = todos.filter(todo => todo.type === 'todo');
+  const timelineItems = todos.filter(todo => todo.type === 'timeline');
+
+  return (
+    <div className="app-container">
+      <div style={{ display: 'flex', justifyContent: 'flex-end', padding: '8px' }}>
+        <button onClick={() => setToken(null)}>Logout</button>
+      </div>
+      <Tabs>
+        <TabList>
+          <Tab>To-Do List</Tab>
+          {timelineEnabled && <Tab>Timeline</Tab>}
+        </TabList>
+        <TabPanel>
+          <TodoForm addTodo={addTodo} />
+          <TodoList
+            todos={todoItems}
+            toggleComplete={toggleComplete}
+            deleteTodo={deleteTodo}
+          />
+        </TabPanel>
+        {timelineEnabled && (
+          <TabPanel>
+            <TimelineComponent todos={timelineItems} />
+          </TabPanel>
+        )}
+      </Tabs>
+    </div>
+  );
+};
+
+export default App;
+```
+
+- [ ] **Step 2: Replace frontend/src/App.test.tsx**
+
+```tsx
+import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
+import App from './App';
+import * as api from './services/api';
+import * as auth from './services/auth';
+import { Todo } from './types/todo';
+import '@testing-library/jest-dom';
+
+jest.mock('./services/api');
+jest.mock('./services/auth');
+
+const mockTodos: Todo[] = [
+  {
+    id: 1,
+    title: 'Test Todo',
+    completed: false,
+    created_at: '2024-08-31T12:00:00Z',
+    updated_at: '2024-08-31T12:00:00Z',
+    type: 'todo',
+  },
+];
+
+// Helper: simulate login so todo UI is visible
+const loginAndRender = async (todosResult: Todo[] = []) => {
+  (auth.login as jest.Mock).mockResolvedValueOnce('test-token');
+  (api.getTodos as jest.Mock).mockResolvedValueOnce(todosResult);
+  render(<App />);
+  fireEvent.change(screen.getByPlaceholderText('Username'), { target: { value: 'alice' } });
+  fireEvent.change(screen.getByPlaceholderText('Password'), { target: { value: 'password123' } });
+  await act(async () => {
+    fireEvent.submit(screen.getByRole('button', { name: /log in/i }).closest('form')!);
+  });
+  await waitFor(() => expect(screen.queryByText(/loading/i)).not.toBeInTheDocument());
+};
+
+describe('App Component', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('shows AuthForm when not authenticated', () => {
+    render(<App />);
+    expect(screen.getByRole('heading', { name: /log in/i })).toBeInTheDocument();
+  });
+
+  test('shows Logout button after login', async () => {
+    await loginAndRender([]);
+    expect(screen.getByRole('button', { name: /logout/i })).toBeInTheDocument();
+  });
+
+  test('returns to AuthForm after logout', async () => {
+    await loginAndRender([]);
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /logout/i }));
+    });
+    expect(screen.getByRole('heading', { name: /log in/i })).toBeInTheDocument();
+  });
+
+  test('renders loading state', async () => {
+    (auth.login as jest.Mock).mockResolvedValueOnce('test-token');
+    (api.getTodos as jest.Mock).mockResolvedValueOnce(mockTodos);
+    render(<App />);
+    fireEvent.change(screen.getByPlaceholderText('Username'), { target: { value: 'alice' } });
+    fireEvent.change(screen.getByPlaceholderText('Password'), { target: { value: 'password123' } });
+    await act(async () => {
+      fireEvent.submit(screen.getByRole('button', { name: /log in/i }).closest('form')!);
+    });
+    expect(screen.getByText(/Loading.../i)).toBeInTheDocument();
+    await waitFor(() => expect(screen.queryByText(/Loading.../i)).not.toBeInTheDocument());
+  });
+
+  test('renders todos after fetch', async () => {
+    await loginAndRender(mockTodos);
+    expect(screen.getByText('Test Todo')).toBeInTheDocument();
+  });
+
+  test('shows error if fetchTodos fails', async () => {
+    (auth.login as jest.Mock).mockResolvedValueOnce('test-token');
+    (api.getTodos as jest.Mock).mockRejectedValueOnce(new Error('API Error'));
+    render(<App />);
+    fireEvent.change(screen.getByPlaceholderText('Username'), { target: { value: 'alice' } });
+    fireEvent.change(screen.getByPlaceholderText('Password'), { target: { value: 'password123' } });
+    await act(async () => {
+      fireEvent.submit(screen.getByRole('button', { name: /log in/i }).closest('form')!);
+    });
+    await waitFor(() => {
+      expect(screen.getByText(/Failed to fetch todos/i)).toBeInTheDocument();
+    });
+  });
+
+  test('adds a todo', async () => {
+    (api.addTodo as jest.Mock).mockResolvedValueOnce({ ...mockTodos[0], id: 2, title: 'New Todo' });
+    await loginAndRender([]);
+    const input = screen.getByPlaceholderText(/Add a new task/i);
+    await act(async () => {
+      fireEvent.change(input, { target: { value: 'New Todo' } });
+      fireEvent.submit(input.closest('form')!);
+    });
+    await waitFor(() => {
+      expect(screen.getByText('New Todo')).toBeInTheDocument();
+    });
+  });
+
+  test('toggles todo completion', async () => {
+    (api.updateTodo as jest.Mock).mockResolvedValueOnce({ ...mockTodos[0], completed: true });
+    await loginAndRender(mockTodos);
+    const checkbox = screen.getByRole('checkbox');
+    await act(async () => { fireEvent.click(checkbox); });
+    await waitFor(() => { expect(api.updateTodo).toHaveBeenCalled(); });
+  });
+
+  test('deletes a todo', async () => {
+    (api.deleteTodo as jest.Mock).mockResolvedValueOnce(undefined);
+    await loginAndRender(mockTodos);
+    const deleteButton = screen.getByRole('button', { name: /delete/i });
+    await act(async () => { fireEvent.click(deleteButton); });
+    await waitFor(() => {
+      expect(api.deleteTodo).toHaveBeenCalled();
+      expect(screen.queryByText('Test Todo')).not.toBeInTheDocument();
+    });
+  });
+
+  test('shows error if addTodo fails', async () => {
+    (api.addTodo as jest.Mock).mockRejectedValueOnce(new Error('API Error'));
+    await loginAndRender([]);
+    const input = screen.getByPlaceholderText(/Add a new task/i);
+    await act(async () => {
+      fireEvent.change(input, { target: { value: 'Fail Todo' } });
+      fireEvent.submit(input.closest('form')!);
+    });
+    await waitFor(() => {
+      expect(screen.getByText(/Failed to add todo/i)).toBeInTheDocument();
+    });
+  });
+});
+```
+
+- [ ] **Step 3: Run all frontend tests**
+
+```bash
+cd frontend && npm test -- --watchAll=false
+```
+
+Expected: all test suites pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/App.tsx frontend/src/App.test.tsx
+git commit -m "feat: add auth gate, token state, logout, and 401 re-login to App.tsx"
+```
+
+---
+
+## Final verification
+
+- [ ] **Run all backend tests**
+
+```bash
+docker compose run --rm backend python -m pytest tests/ -v
+```
+
+Expected: all tests pass.
+
+- [ ] **Run all frontend tests**
+
+```bash
+cd frontend && npm test -- --watchAll=false
+```
+
+Expected: all test suites pass.
+
+- [ ] **End-to-end smoke test**
+
+```bash
+docker compose up -d
+```
+
+1. Open `http://localhost:3000` — should show the login/register form
+2. Register a new user
+3. Add a few todos — verify they appear
+4. Log out — login form reappears
+5. Log back in — same todos visible
+6. Register a second user — their todo list is empty
+
+```bash
+docker compose down
+```

--- a/docs/superpowers/specs/2026-03-23-auth-design.md
+++ b/docs/superpowers/specs/2026-03-23-auth-design.md
@@ -1,0 +1,238 @@
+# Basic Authentication Design
+
+**Date:** 2026-03-23
+
+## Goal
+
+Add JWT-based registration and login to the todo app. All `/todos` endpoints require a valid token. Todos are per-user — each user sees and manages only their own data.
+
+## Context
+
+- Backend: FastAPI + SQLAlchemy Core (async) + asyncpg + Postgres
+- Frontend: React SPA using `fetch` for all API calls
+- Currently no auth — all endpoints are public and todos are shared globally
+- No migration tooling (Alembic); schema changes applied via `create_all` + manual `ALTER TABLE` statements in `create_db_and_tables()`
+
+---
+
+## Backend Changes
+
+### New dependencies (`backend/requirements.txt`)
+
+```
+python-jose[cryptography]==3.3.0
+passlib[bcrypt]==1.7.4
+```
+
+### `backend/settings.py`
+
+Add two new fields:
+
+```python
+SECRET_KEY: str  # required — no default, must be set via env var or .env
+ACCESS_TOKEN_EXPIRE_MINUTES: int = 30
+```
+
+`SECRET_KEY` has no default so startup fails loudly if it is not configured. In `docker-compose.yml`, add `SECRET_KEY=dev-secret-key-change-in-production` to the backend environment.
+
+### DB schema (`backend/database.py`)
+
+**New `users` table:**
+
+```python
+users = Table(
+    "users",
+    metadata,
+    Column("id", Integer, primary_key=True),
+    Column("username", String, unique=True, nullable=False),
+    Column("hashed_password", String, nullable=False),
+    Column("created_at", DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False),
+)
+```
+
+**`todos` table:** add `user_id` column:
+
+```python
+Column("user_id", Integer, ForeignKey("users.id"), nullable=False),
+```
+
+### Migration strategy
+
+`metadata.create_all` creates new tables but does not alter existing ones. `create_db_and_tables()` is extended to run:
+
+```sql
+ALTER TABLE todos ADD COLUMN IF NOT EXISTS user_id INTEGER REFERENCES users(id);
+```
+
+**Existing databases with data:** existing todos have no `user_id` and cannot be migrated automatically (no user to assign them to). Developers must reset the volume:
+
+```bash
+docker compose down -v
+docker compose up
+```
+
+This is acceptable for a project at this stage.
+
+### `backend/auth.py` (new file)
+
+Single responsibility: password hashing and JWT sign/verify.
+
+```
+Functions:
+  hash_password(plain: str) -> str
+  verify_password(plain: str, hashed: str) -> bool
+  create_access_token(data: dict) -> str   # signs JWT, sets exp
+  decode_access_token(token: str) -> dict  # verifies + decodes, raises on invalid/expired
+
+FastAPI dependency:
+  get_current_user(token: str = Depends(oauth2_scheme), conn = Depends(get_db_conn)) -> UserRow
+    - Decodes token, looks up user by username in DB
+    - Raises HTTP 401 if token invalid, expired, or user not found
+```
+
+Uses `OAuth2PasswordBearer(tokenUrl="/auth/login")` for the `oauth2_scheme` dependency.
+
+### `backend/models.py`
+
+New Pydantic models:
+
+```python
+class UserCreate(BaseModel):
+    username: str
+    password: str
+
+class UserPublic(BaseModel):
+    id: int
+    username: str
+
+class Token(BaseModel):
+    access_token: str
+    token_type: str = "bearer"
+```
+
+### New routes in `backend/main.py`
+
+```
+POST /auth/register
+  Body: UserCreate
+  - Check username not already taken (409 if duplicate)
+  - Hash password, insert into users
+  - Return Token
+
+POST /auth/login
+  Body: OAuth2PasswordRequestForm (username + password form fields)
+  - Look up user by username (401 if not found)
+  - Verify password hash (401 if mismatch)
+  - Return Token
+```
+
+### Updated `/todos` endpoints
+
+All five todo endpoints (`GET /todos`, `GET /todos/{id}`, `POST /todos`, `PUT /todos/{id}`, `DELETE /todos/{id}`) add:
+
+```python
+current_user = Depends(get_current_user)
+```
+
+Query changes:
+- `GET /todos` — `WHERE user_id = current_user.id`
+- `GET /todos/{id}` — `WHERE id = todo_id AND user_id = current_user.id`
+- `POST /todos` — `INSERT ... user_id = current_user.id`
+- `PUT /todos/{id}` — `WHERE id = todo_id AND user_id = current_user.id`
+- `DELETE /todos/{id}` — `WHERE id = todo_id AND user_id = current_user.id`
+
+For GET/PUT/DELETE by ID: if the todo doesn't exist **or** belongs to another user, return `404 Not Found` (no information leakage).
+
+`GET /` health check remains public.
+
+---
+
+## Frontend Changes
+
+### `frontend/src/services/auth.ts` (new file)
+
+```typescript
+export const register(username: string, password: string): Promise<string>  // returns token
+export const login(username: string, password: string): Promise<string>      // returns token
+```
+
+Both call the backend and extract `access_token` from the response.
+
+### `frontend/src/components/AuthForm.tsx` (new file)
+
+Single form for both register and login with a mode toggle. Props:
+
+```typescript
+interface AuthFormProps {
+  onAuth: (token: string) => void;
+}
+```
+
+Shows username + password inputs. Submit calls `register` or `login` from `auth.ts`. On success, calls `onAuth(token)`. Shows inline error on failure.
+
+### `frontend/src/services/api.ts`
+
+All four functions (`getTodos`, `addTodo`, `updateTodo`, `deleteTodo`) gain a `token: string` parameter and pass `Authorization: Bearer <token>` in the request headers.
+
+### `frontend/src/App.tsx`
+
+- Add `const [token, setToken] = useState<string | null>(null)` state
+- If `token` is null: render `<AuthForm onAuth={setToken} />`
+- If `token` is set: render existing todo UI, pass `token` to all `api.*` calls
+- Add a **Logout** button that calls `setToken(null)`
+
+Token is in React state only (not `localStorage`). Page refresh requires re-login.
+
+---
+
+## Testing Strategy
+
+### Backend
+
+`backend/tests/test_auth.py` (new file) — tests for:
+- `POST /auth/register` happy path and duplicate username
+- `POST /auth/login` happy path and wrong password
+- `GET /todos` returns 401 without token
+- `GET /todos` returns only current user's todos (not another user's)
+
+### Frontend
+
+`frontend/src/components/AuthForm.test.tsx` (new file) — tests for:
+- Renders login mode by default
+- Switches to register mode on toggle
+- Calls `onAuth` with token on successful login
+- Shows error message on failed login
+
+`frontend/src/services/api.test.ts` — update existing tests to pass a dummy token and verify `Authorization` header is included in requests.
+
+---
+
+## Docker Compose
+
+Add to backend `environment`:
+
+```yaml
+- SECRET_KEY=dev-secret-key-change-in-production
+```
+
+---
+
+## Files Changed
+
+| File | Action | What changes |
+|---|---|---|
+| `backend/requirements.txt` | Modify | Add `python-jose[cryptography]`, `passlib[bcrypt]` |
+| `backend/settings.py` | Modify | Add `SECRET_KEY`, `ACCESS_TOKEN_EXPIRE_MINUTES` |
+| `backend/database.py` | Modify | Add `users` table, `user_id` FK on `todos`, migration step |
+| `backend/auth.py` | Create | Password hashing, JWT utilities, `get_current_user` dependency |
+| `backend/models.py` | Modify | Add `UserCreate`, `UserPublic`, `Token` |
+| `backend/main.py` | Modify | Add `/auth/register`, `/auth/login`; protect all `/todos` endpoints |
+| `backend/tests/test_auth.py` | Create | Auth endpoint tests |
+| `backend/tests/test_endpoints.py` | Modify | Update fixture to create user + obtain token before tests |
+| `docker-compose.yml` | Modify | Add `SECRET_KEY` to backend environment |
+| `frontend/src/services/auth.ts` | Create | `register` and `login` API functions |
+| `frontend/src/components/AuthForm.tsx` | Create | Login/register form component |
+| `frontend/src/services/api.ts` | Modify | Add `token` param, `Authorization` header to all calls |
+| `frontend/src/App.tsx` | Modify | Auth state, conditional render, logout button |
+| `frontend/src/components/AuthForm.test.tsx` | Create | AuthForm unit tests |
+| `frontend/src/services/api.test.ts` | Modify | Update tests to verify Authorization header |

--- a/docs/superpowers/specs/2026-03-23-auth-design.md
+++ b/docs/superpowers/specs/2026-03-23-auth-design.md
@@ -11,7 +11,7 @@ Add JWT-based registration and login to the todo app. All `/todos` endpoints req
 - Backend: FastAPI + SQLAlchemy Core (async) + asyncpg + Postgres
 - Frontend: React SPA using `fetch` for all API calls
 - Currently no auth — all endpoints are public and todos are shared globally
-- No migration tooling (Alembic); schema changes applied via `create_all` + manual `ALTER TABLE` statements in `create_db_and_tables()`
+- No migration tooling (Alembic); schema changes applied via `create_all` + explicit `ALTER TABLE` in `create_db_and_tables()`
 
 ---
 
@@ -20,22 +20,26 @@ Add JWT-based registration and login to the todo app. All `/todos` endpoints req
 ### New dependencies (`backend/requirements.txt`)
 
 ```
-python-jose[cryptography]==3.3.0
+PyJWT==2.8.0
 passlib[bcrypt]==1.7.4
 ```
+
+`PyJWT` replaces `python-jose` (unmaintained since 2022, CVE-2024-33663). `PyJWT` is actively maintained and the current community standard.
 
 ### `backend/settings.py`
 
 Add two new fields:
 
 ```python
-SECRET_KEY: str  # required — no default, must be set via env var or .env
+SECRET_KEY: str  # required — no default, startup fails loudly if unset
 ACCESS_TOKEN_EXPIRE_MINUTES: int = 30
 ```
 
-`SECRET_KEY` has no default so startup fails loudly if it is not configured. In `docker-compose.yml`, add `SECRET_KEY=dev-secret-key-change-in-production` to the backend environment.
+In `docker-compose.yml`, add `SECRET_KEY=dev-secret-key-change-in-production` to the backend environment.
 
-### DB schema (`backend/database.py`)
+### `backend/database.py`
+
+**Move `get_db_conn` here** (currently in `main.py`). This avoids a circular import: `auth.py` needs `get_db_conn`, and `main.py` imports from `auth.py`.
 
 **New `users` table:**
 
@@ -58,37 +62,44 @@ Column("user_id", Integer, ForeignKey("users.id"), nullable=False),
 
 ### Migration strategy
 
-`metadata.create_all` creates new tables but does not alter existing ones. `create_db_and_tables()` is extended to run:
+`metadata.create_all` creates new tables but does not alter existing ones. After `create_all` runs (which guarantees `users` exists), `create_db_and_tables()` executes:
 
 ```sql
-ALTER TABLE todos ADD COLUMN IF NOT EXISTS user_id INTEGER REFERENCES users(id);
+ALTER TABLE todos ADD COLUMN IF NOT EXISTS user_id INTEGER NOT NULL REFERENCES users(id);
 ```
 
-**Existing databases with data:** existing todos have no `user_id` and cannot be migrated automatically (no user to assign them to). Developers must reset the volume:
+The `NOT NULL` constraint matches the column definition. This statement is safe to run on a fresh DB (column doesn't exist yet) and a no-op via `IF NOT EXISTS` on a DB where the column is already present.
+
+**Existing databases with data:** todos with no `user_id` cannot be migrated (no user to assign them to). The `NOT NULL` constraint would reject the `ALTER TABLE` if any rows exist. Developers must reset the volume:
 
 ```bash
-docker compose down -v
-docker compose up
+docker compose down -v && docker compose up
 ```
 
 This is acceptable for a project at this stage.
 
 ### `backend/auth.py` (new file)
 
-Single responsibility: password hashing and JWT sign/verify.
+Single responsibility: password hashing and JWT sign/verify. Imports `get_db_conn` from `database.py` (not `main.py`).
 
 ```
 Functions:
   hash_password(plain: str) -> str
   verify_password(plain: str, hashed: str) -> bool
-  create_access_token(data: dict) -> str   # signs JWT, sets exp
-  decode_access_token(token: str) -> dict  # verifies + decodes, raises on invalid/expired
+  create_access_token(data: dict) -> str
+    - Signs JWT with HS256 algorithm, sets `exp` claim
+  decode_access_token(token: str) -> dict
+    - Decodes and verifies JWT with algorithms=["HS256"] pinned
+    - Raises HTTP 401 on invalid signature, wrong algorithm, or expired token
 
 FastAPI dependency:
   get_current_user(token: str = Depends(oauth2_scheme), conn = Depends(get_db_conn)) -> UserRow
-    - Decodes token, looks up user by username in DB
-    - Raises HTTP 401 if token invalid, expired, or user not found
+    - Calls decode_access_token, extracts `sub` (username)
+    - Looks up user in DB by username
+    - Raises HTTP 401 if token invalid/expired or user not found
 ```
+
+Algorithm is pinned to `HS256` in both sign and verify to prevent algorithm confusion attacks (`alg: none`).
 
 Uses `OAuth2PasswordBearer(tokenUrl="/auth/login")` for the `oauth2_scheme` dependency.
 
@@ -101,6 +112,13 @@ class UserCreate(BaseModel):
     username: str
     password: str
 
+    @field_validator('password')
+    @classmethod
+    def password_min_length(cls, v):
+        if len(v) < 8:
+            raise ValueError('Password must be at least 8 characters')
+        return v
+
 class UserPublic(BaseModel):
     id: int
     username: str
@@ -112,36 +130,34 @@ class Token(BaseModel):
 
 ### New routes in `backend/main.py`
 
+`get_db_conn` import moves from definition here to `from database import get_db_conn`.
+
 ```
 POST /auth/register
-  Body: UserCreate
-  - Check username not already taken (409 if duplicate)
-  - Hash password, insert into users
+  Body: UserCreate (JSON)
+  - Validate: password >= 8 chars (Pydantic validator)
+  - Check username not already taken (409 Conflict if duplicate)
+  - hash_password, insert into users
   - Return Token
 
 POST /auth/login
   Body: OAuth2PasswordRequestForm (username + password form fields)
   - Look up user by username (401 if not found)
-  - Verify password hash (401 if mismatch)
+  - verify_password (401 if mismatch)
   - Return Token
 ```
 
 ### Updated `/todos` endpoints
 
-All five todo endpoints (`GET /todos`, `GET /todos/{id}`, `POST /todos`, `PUT /todos/{id}`, `DELETE /todos/{id}`) add:
+All five todo endpoints add `current_user = Depends(get_current_user)`. Query changes:
 
-```python
-current_user = Depends(get_current_user)
-```
-
-Query changes:
 - `GET /todos` — `WHERE user_id = current_user.id`
 - `GET /todos/{id}` — `WHERE id = todo_id AND user_id = current_user.id`
 - `POST /todos` — `INSERT ... user_id = current_user.id`
 - `PUT /todos/{id}` — `WHERE id = todo_id AND user_id = current_user.id`
 - `DELETE /todos/{id}` — `WHERE id = todo_id AND user_id = current_user.id`
 
-For GET/PUT/DELETE by ID: if the todo doesn't exist **or** belongs to another user, return `404 Not Found` (no information leakage).
+For GET/PUT/DELETE by ID: if the todo doesn't exist **or** belongs to another user → `404 Not Found` (no information leakage).
 
 `GET /` health check remains public.
 
@@ -156,11 +172,11 @@ export const register(username: string, password: string): Promise<string>  // r
 export const login(username: string, password: string): Promise<string>      // returns token
 ```
 
-Both call the backend and extract `access_token` from the response.
+Both POST to `/auth/register` and `/auth/login` respectively and extract `access_token` from the JSON response.
 
 ### `frontend/src/components/AuthForm.tsx` (new file)
 
-Single form for both register and login with a mode toggle. Props:
+Single form handling both register and login, toggled by a "Switch to Register / Switch to Login" link. Props:
 
 ```typescript
 interface AuthFormProps {
@@ -168,20 +184,27 @@ interface AuthFormProps {
 }
 ```
 
-Shows username + password inputs. Submit calls `register` or `login` from `auth.ts`. On success, calls `onAuth(token)`. Shows inline error on failure.
+Shows username + password inputs. On submit calls `register` or `login` from `auth.ts`. On success calls `onAuth(token)`. Shows inline error message on failure.
 
 ### `frontend/src/services/api.ts`
 
-All four functions (`getTodos`, `addTodo`, `updateTodo`, `deleteTodo`) gain a `token: string` parameter and pass `Authorization: Bearer <token>` in the request headers.
+All four functions gain a `token: string` parameter and an optional `onUnauthorized?: () => void` callback. They pass `Authorization: Bearer <token>` in request headers. On a 401 response, `onUnauthorized?.()` is called before throwing. Example signature:
+
+```typescript
+export const getTodos = async (token: string, onUnauthorized?: () => void): Promise<Todo[]>
+```
+
+All four functions follow this same signature shape.
 
 ### `frontend/src/App.tsx`
 
 - Add `const [token, setToken] = useState<string | null>(null)` state
-- If `token` is null: render `<AuthForm onAuth={setToken} />`
-- If `token` is set: render existing todo UI, pass `token` to all `api.*` calls
+- If `token` is null → render `<AuthForm onAuth={setToken} />`
+- If `token` is set → render existing todo UI, pass `token` to all `api.*` calls
 - Add a **Logout** button that calls `setToken(null)`
+- **401 mid-session handling:** all `api.*` calls that receive a 401 response throw an error; the existing `catch` blocks in `App.tsx` set the error state. Additionally, on a 401 response, `setToken(null)` is called to return the user to the login screen. The `api.ts` functions accept an optional `onUnauthorized` callback for this purpose, called before throwing when response status is 401.
 
-Token is in React state only (not `localStorage`). Page refresh requires re-login.
+Token stored in React state only (not `localStorage`). Page refresh requires re-login.
 
 ---
 
@@ -190,20 +213,41 @@ Token is in React state only (not `localStorage`). Page refresh requires re-logi
 ### Backend
 
 `backend/tests/test_auth.py` (new file) — tests for:
-- `POST /auth/register` happy path and duplicate username
-- `POST /auth/login` happy path and wrong password
-- `GET /todos` returns 401 without token
-- `GET /todos` returns only current user's todos (not another user's)
+- `POST /auth/register` happy path (returns token)
+- `POST /auth/register` duplicate username → 409
+- `POST /auth/register` short password → 422
+- `POST /auth/login` happy path (returns token)
+- `POST /auth/login` wrong password → 401
+- `GET /todos` without token → 401
+- `GET /todos` with token returns only the current user's todos (not another user's)
+
+`backend/tests/test_endpoints.py` — update `reset_state` fixture to truncate both tables with CASCADE (FK-safe):
+
+```python
+await conn.execute(text("TRUNCATE TABLE todos, users RESTART IDENTITY CASCADE"))
+```
+
+Also add a `user_token` fixture that registers a test user and returns a token. The module-level `client` becomes a function-scoped `client` fixture that constructs `TestClient` with the token pre-set:
+
+```python
+@pytest.fixture
+def client(user_token):
+    return TestClient(app, headers={"Authorization": f"Bearer {user_token}"})
+```
+
+All existing test methods receive `client` as a parameter instead of using the module-level variable.
 
 ### Frontend
 
 `frontend/src/components/AuthForm.test.tsx` (new file) — tests for:
 - Renders login mode by default
-- Switches to register mode on toggle
+- Toggles to register mode
 - Calls `onAuth` with token on successful login
 - Shows error message on failed login
 
-`frontend/src/services/api.test.ts` — update existing tests to pass a dummy token and verify `Authorization` header is included in requests.
+`frontend/src/services/api.test.ts` — update existing tests to pass a dummy token and verify `Authorization: Bearer <token>` header is sent.
+
+`frontend/src/App.test.tsx` — update existing mocks: `api.getTodos` etc. now take a `token` parameter; update mock signatures accordingly.
 
 ---
 
@@ -221,18 +265,19 @@ Add to backend `environment`:
 
 | File | Action | What changes |
 |---|---|---|
-| `backend/requirements.txt` | Modify | Add `python-jose[cryptography]`, `passlib[bcrypt]` |
+| `backend/requirements.txt` | Modify | Add `PyJWT`, `passlib[bcrypt]` |
 | `backend/settings.py` | Modify | Add `SECRET_KEY`, `ACCESS_TOKEN_EXPIRE_MINUTES` |
-| `backend/database.py` | Modify | Add `users` table, `user_id` FK on `todos`, migration step |
-| `backend/auth.py` | Create | Password hashing, JWT utilities, `get_current_user` dependency |
-| `backend/models.py` | Modify | Add `UserCreate`, `UserPublic`, `Token` |
-| `backend/main.py` | Modify | Add `/auth/register`, `/auth/login`; protect all `/todos` endpoints |
+| `backend/database.py` | Modify | Move `get_db_conn` here; add `users` table, `user_id` FK on `todos`, migration step |
+| `backend/auth.py` | Create | Password hashing, JWT (HS256 pinned), `get_current_user` dependency |
+| `backend/models.py` | Modify | Add `UserCreate` (with password validator), `UserPublic`, `Token` |
+| `backend/main.py` | Modify | Add `/auth/register`, `/auth/login`; protect all `/todos` endpoints; import `get_db_conn` from `database` |
 | `backend/tests/test_auth.py` | Create | Auth endpoint tests |
-| `backend/tests/test_endpoints.py` | Modify | Update fixture to create user + obtain token before tests |
+| `backend/tests/test_endpoints.py` | Modify | Update `reset_state` to truncate users CASCADE; add `user_token` fixture |
 | `docker-compose.yml` | Modify | Add `SECRET_KEY` to backend environment |
 | `frontend/src/services/auth.ts` | Create | `register` and `login` API functions |
 | `frontend/src/components/AuthForm.tsx` | Create | Login/register form component |
-| `frontend/src/services/api.ts` | Modify | Add `token` param, `Authorization` header to all calls |
-| `frontend/src/App.tsx` | Modify | Auth state, conditional render, logout button |
+| `frontend/src/services/api.ts` | Modify | Add `token` param + `Authorization` header; `onUnauthorized` callback on 401 |
+| `frontend/src/App.tsx` | Modify | Auth state, conditional render, logout, 401 → re-login handling |
 | `frontend/src/components/AuthForm.test.tsx` | Create | AuthForm unit tests |
-| `frontend/src/services/api.test.ts` | Modify | Update tests to verify Authorization header |
+| `frontend/src/services/api.test.ts` | Modify | Verify Authorization header in all API call tests |
+| `frontend/src/App.test.tsx` | Modify | Update mock signatures for token parameter |

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -43,7 +43,8 @@ form {
   align-items: stretch;
 }
 
-input[type="text"] {
+input[type="text"],
+input[type="password"] {
   flex: 1;
   padding: 14px 18px;
   border: 2px solid #e1e8ed;
@@ -54,14 +55,16 @@ input[type="text"] {
   outline: none;
 }
 
-input[type="text"]:focus {
+input[type="text"]:focus,
+input[type="password"]:focus {
   border-color: #667eea;
   background-color: #ffffff;
   box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
   transform: translateY(-1px);
 }
 
-input[type="text"]::placeholder {
+input[type="text"]::placeholder,
+input[type="password"]::placeholder {
   color: #8e9aaf;
 }
 
@@ -179,6 +182,85 @@ button.delete:hover {
   background-color: #f8f9fa;
   border-radius: 12px;
   border: 2px dashed #dee2e6;
+}
+
+/* Auth card */
+.auth-container {
+  background-color: #ffffff;
+  padding: 40px;
+  border-radius: 16px;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.1), 0 6px 20px rgba(0, 0, 0, 0.05);
+  width: 100%;
+  max-width: 420px;
+  text-align: center;
+}
+
+.auth-container h2 {
+  color: #2c3e50;
+  margin: 0 0 28px;
+  font-size: 1.8rem;
+  font-weight: 700;
+  letter-spacing: -0.3px;
+}
+
+.auth-form {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  margin-bottom: 16px;
+}
+
+.auth-form input {
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.auth-error {
+  color: #e74c3c;
+  font-size: 14px;
+  margin: 0 0 14px;
+  padding: 10px 14px;
+  background-color: #fdf0ef;
+  border-radius: 8px;
+  border: 1px solid #f5c6c2;
+}
+
+.auth-switch-btn {
+  background: transparent;
+  color: #667eea;
+  box-shadow: none;
+  font-size: 14px;
+  font-weight: 500;
+  padding: 8px 16px;
+  border: 2px solid #667eea;
+  margin-top: 4px;
+}
+
+.auth-switch-btn:hover {
+  background: rgba(102, 126, 234, 0.06);
+  box-shadow: none;
+  transform: none;
+}
+
+/* Logout button */
+.logout-btn {
+  background: transparent;
+  color: #6c757d;
+  box-shadow: none;
+  font-size: 13px;
+  font-weight: 500;
+  padding: 7px 16px;
+  border: 1px solid #dee2e6;
+  border-radius: 8px;
+  min-width: unset;
+}
+
+.logout-btn:hover {
+  background: #f8f9fa;
+  color: #2c3e50;
+  box-shadow: none;
+  transform: none;
+  border-color: #adb5bd;
 }
 
 /* Responsive design */

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,11 +1,12 @@
 import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
 import App from './App';
 import * as api from './services/api';
+import * as auth from './services/auth';
 import { Todo } from './types/todo';
 import '@testing-library/jest-dom';
 
-// Mock API service
 jest.mock('./services/api');
+jest.mock('./services/auth');
 
 const mockTodos: Todo[] = [
   {
@@ -18,103 +19,117 @@ const mockTodos: Todo[] = [
   },
 ];
 
+// Helper: simulate login so todo UI is visible
+const loginAndRender = async (todosResult: Todo[] = []) => {
+  (auth.login as jest.Mock).mockResolvedValueOnce('test-token');
+  (api.getTodos as jest.Mock).mockResolvedValueOnce(todosResult);
+  render(<App />);
+  fireEvent.change(screen.getByPlaceholderText('Username'), { target: { value: 'alice' } });
+  fireEvent.change(screen.getByPlaceholderText('Password'), { target: { value: 'password123' } });
+  await act(async () => {
+    fireEvent.submit(screen.getByRole('button', { name: /log in/i }).closest('form')!);
+  });
+  await waitFor(() => expect(screen.queryByText(/loading/i)).not.toBeInTheDocument());
+};
+
 describe('App Component', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  test('renders loading state', async () => {
-    (api.getTodos as jest.Mock).mockResolvedValueOnce(mockTodos);
+  test('shows AuthForm when not authenticated', () => {
     render(<App />);
+    expect(screen.getByRole('heading', { name: /log in/i })).toBeInTheDocument();
+  });
+
+  test('shows Logout button after login', async () => {
+    await loginAndRender([]);
+    expect(screen.getByRole('button', { name: /logout/i })).toBeInTheDocument();
+  });
+
+  test('returns to AuthForm after logout', async () => {
+    await loginAndRender([]);
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /logout/i }));
+    });
+    expect(screen.getByRole('heading', { name: /log in/i })).toBeInTheDocument();
+  });
+
+  test('renders loading state', async () => {
+    (auth.login as jest.Mock).mockResolvedValueOnce('test-token');
+    let resolveTodos!: (value: Todo[]) => void;
+    const deferredTodos = new Promise<Todo[]>((resolve) => { resolveTodos = resolve; });
+    (api.getTodos as jest.Mock).mockReturnValueOnce(deferredTodos);
+    render(<App />);
+    fireEvent.change(screen.getByPlaceholderText('Username'), { target: { value: 'alice' } });
+    fireEvent.change(screen.getByPlaceholderText('Password'), { target: { value: 'password123' } });
+    await act(async () => {
+      fireEvent.submit(screen.getByRole('button', { name: /log in/i }).closest('form')!);
+    });
     expect(screen.getByText(/Loading.../i)).toBeInTheDocument();
+    await act(async () => { resolveTodos(mockTodos); });
     await waitFor(() => expect(screen.queryByText(/Loading.../i)).not.toBeInTheDocument());
   });
 
   test('renders todos after fetch', async () => {
-    (api.getTodos as jest.Mock).mockResolvedValueOnce(mockTodos);
-    render(<App />);
-    await waitFor(() => {
-      expect(screen.getByText('Test Todo')).toBeInTheDocument();
-    });
+    await loginAndRender(mockTodos);
+    expect(screen.getByText('Test Todo')).toBeInTheDocument();
   });
 
   test('shows error if fetchTodos fails', async () => {
+    (auth.login as jest.Mock).mockResolvedValueOnce('test-token');
     (api.getTodos as jest.Mock).mockRejectedValueOnce(new Error('API Error'));
     render(<App />);
+    fireEvent.change(screen.getByPlaceholderText('Username'), { target: { value: 'alice' } });
+    fireEvent.change(screen.getByPlaceholderText('Password'), { target: { value: 'password123' } });
+    await act(async () => {
+      fireEvent.submit(screen.getByRole('button', { name: /log in/i }).closest('form')!);
+    });
     await waitFor(() => {
       expect(screen.getByText(/Failed to fetch todos/i)).toBeInTheDocument();
     });
   });
 
   test('adds a todo', async () => {
-    (api.getTodos as jest.Mock).mockResolvedValueOnce([]);
-    (api.addTodo as jest.Mock).mockResolvedValueOnce({
-      ...mockTodos[0],
-      id: 2,
-      title: 'New Todo',
-    });
-    render(<App />);
-    await waitFor(() => expect(screen.queryByText(/Loading.../i)).not.toBeInTheDocument());
-
+    (api.addTodo as jest.Mock).mockResolvedValueOnce({ ...mockTodos[0], id: 2, title: 'New Todo' });
+    await loginAndRender([]);
     const input = screen.getByPlaceholderText(/Add a new task/i);
     await act(async () => {
       fireEvent.change(input, { target: { value: 'New Todo' } });
       fireEvent.submit(input.closest('form')!);
     });
-
     await waitFor(() => {
       expect(screen.getByText('New Todo')).toBeInTheDocument();
     });
   });
 
   test('toggles todo completion', async () => {
-    (api.getTodos as jest.Mock).mockResolvedValueOnce(mockTodos);
-    (api.updateTodo as jest.Mock).mockResolvedValueOnce({
-      ...mockTodos[0],
-      completed: true,
-    });
-    render(<App />);
-    await waitFor(() => expect(screen.getByText('Test Todo')).toBeInTheDocument());
-
+    (api.updateTodo as jest.Mock).mockResolvedValueOnce({ ...mockTodos[0], completed: true });
+    await loginAndRender(mockTodos);
     const checkbox = screen.getByRole('checkbox');
-    await act(async () => {
-      fireEvent.click(checkbox);
-    });
-
-    await waitFor(() => {
-      expect(api.updateTodo).toHaveBeenCalled();
-    });
+    await act(async () => { fireEvent.click(checkbox); });
+    await waitFor(() => { expect(api.updateTodo).toHaveBeenCalled(); });
   });
 
   test('deletes a todo', async () => {
-    (api.getTodos as jest.Mock).mockResolvedValueOnce(mockTodos);
     (api.deleteTodo as jest.Mock).mockResolvedValueOnce(undefined);
-    render(<App />);
-    await waitFor(() => expect(screen.getByText('Test Todo')).toBeInTheDocument());
-
+    await loginAndRender(mockTodos);
     const deleteButton = screen.getByRole('button', { name: /delete/i });
-    await act(async () => {
-      fireEvent.click(deleteButton);
-    });
-
+    await act(async () => { fireEvent.click(deleteButton); });
     await waitFor(() => {
-      expect(api.deleteTodo).toHaveBeenCalledWith(1);
+      expect(api.deleteTodo).toHaveBeenCalled();
       expect(screen.queryByText('Test Todo')).not.toBeInTheDocument();
     });
   });
 
   test('shows error if addTodo fails', async () => {
-    (api.getTodos as jest.Mock).mockResolvedValueOnce([]);
     (api.addTodo as jest.Mock).mockRejectedValueOnce(new Error('API Error'));
-    render(<App />);
-    await waitFor(() => expect(screen.queryByText(/Loading.../i)).not.toBeInTheDocument());
-
+    await loginAndRender([]);
     const input = screen.getByPlaceholderText(/Add a new task/i);
     await act(async () => {
       fireEvent.change(input, { target: { value: 'Fail Todo' } });
       fireEvent.submit(input.closest('form')!);
     });
-
     await waitFor(() => {
       expect(screen.getByText(/Failed to add todo/i)).toBeInTheDocument();
     });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,25 +2,30 @@ import React, { useState, useEffect } from 'react';
 import { Todo } from './types/todo';
 import TodoList from './components/TodoList';
 import TodoForm from './components/TodoForm';
-import * as api from './services/api'; // Import the new API service
+import AuthForm from './components/AuthForm';
+import * as api from './services/api';
 import TimelineComponent from './components/Timeline';
 import { Tab, Tabs, TabList, TabPanel } from 'react-tabs';
 import 'react-tabs/style/react-tabs.css';
 import './App.css';
 
 const App: React.FC = () => {
+  const [token, setToken] = useState<string | null>(null);
   const [todos, setTodos] = useState<Todo[]>([]);
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  const handleUnauthorized = () => setToken(null);
+
   useEffect(() => {
-    fetchTodos();
-  }, []);
+    if (token) fetchTodos();
+  }, [token]);
 
   const fetchTodos = async () => {
+    if (!token) return;
     try {
       setLoading(true);
-      const data = await api.getTodos();
+      const data = await api.getTodos(token, handleUnauthorized);
       setTodos(data);
     } catch (err) {
       setError('Failed to fetch todos.');
@@ -31,8 +36,9 @@ const App: React.FC = () => {
   };
 
   const addTodo = async (text: string) => {
+    if (!token) return;
     try {
-      const newTodo = await api.addTodo(text);
+      const newTodo = await api.addTodo(text, token, handleUnauthorized);
       setTodos((prevTodos) => [...prevTodos, newTodo]);
     } catch (err) {
       setError('Failed to add todo.');
@@ -41,14 +47,13 @@ const App: React.FC = () => {
   };
 
   const toggleComplete = async (id: number) => {
+    if (!token) return;
     const todoToUpdate = todos.find(todo => todo.id === id);
     if (!todoToUpdate) return;
-
     const updatedTodo = { ...todoToUpdate, completed: !todoToUpdate.completed };
-    
     try {
-      await api.updateTodo(id, updatedTodo);
-      setTodos((prevTodos) => 
+      await api.updateTodo(id, updatedTodo, token, handleUnauthorized);
+      setTodos((prevTodos) =>
         prevTodos.map((todo) => (todo.id === id ? updatedTodo : todo))
       );
     } catch (err) {
@@ -58,14 +63,19 @@ const App: React.FC = () => {
   };
 
   const deleteTodo = async (id: number) => {
+    if (!token) return;
     try {
-      await api.deleteTodo(id);
+      await api.deleteTodo(id, token, handleUnauthorized);
       setTodos((prevTodos) => prevTodos.filter((todo) => todo.id !== id));
     } catch (err) {
       setError('Failed to delete todo.');
       console.error(err);
     }
   };
+
+  if (!token) {
+    return <AuthForm onAuth={setToken} />;
+  }
 
   if (loading) {
     return <div>Loading...</div>;
@@ -76,18 +86,19 @@ const App: React.FC = () => {
   }
 
   const timelineEnabled = process.env.REACT_APP_TIMELINE_FEATURE_FLAG === 'true';
-
   const todoItems = todos.filter(todo => todo.type === 'todo');
   const timelineItems = todos.filter(todo => todo.type === 'timeline');
 
   return (
     <div className="app-container">
+      <div style={{ display: 'flex', justifyContent: 'flex-end', padding: '8px' }}>
+        <button onClick={() => setToken(null)}>Logout</button>
+      </div>
       <Tabs>
         <TabList>
           <Tab>To-Do List</Tab>
           {timelineEnabled && <Tab>Timeline</Tab>}
         </TabList>
-
         <TabPanel>
           <TodoForm addTodo={addTodo} />
           <TodoList

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -91,8 +91,8 @@ const App: React.FC = () => {
 
   return (
     <div className="app-container">
-      <div style={{ display: 'flex', justifyContent: 'flex-end', padding: '8px' }}>
-        <button onClick={() => setToken(null)}>Logout</button>
+      <div style={{ display: 'flex', justifyContent: 'flex-end', padding: '8px 0 4px' }}>
+        <button className="logout-btn" onClick={() => setToken(null)}>Logout</button>
       </div>
       <Tabs>
         <TabList>

--- a/frontend/src/components/AuthForm.test.tsx
+++ b/frontend/src/components/AuthForm.test.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import AuthForm from './AuthForm';
+import * as auth from '../services/auth';
+
+jest.mock('../services/auth');
+
+describe('AuthForm', () => {
+  const onAuth = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('renders login mode by default', () => {
+    render(<AuthForm onAuth={onAuth} />);
+    expect(screen.getByRole('heading', { name: /log in/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /log in/i })).toBeInTheDocument();
+  });
+
+  test('switches to register mode when toggle is clicked', () => {
+    render(<AuthForm onAuth={onAuth} />);
+    fireEvent.click(screen.getByRole('button', { name: /switch to register/i }));
+    expect(screen.getByRole('heading', { name: /register/i })).toBeInTheDocument();
+  });
+
+  test('calls onAuth with token on successful login', async () => {
+    (auth.login as jest.Mock).mockResolvedValueOnce('my-token');
+    render(<AuthForm onAuth={onAuth} />);
+    fireEvent.change(screen.getByPlaceholderText('Username'), { target: { value: 'alice' } });
+    fireEvent.change(screen.getByPlaceholderText('Password'), { target: { value: 'password123' } });
+    await act(async () => {
+      fireEvent.submit(screen.getByRole('button', { name: /log in/i }).closest('form')!);
+    });
+    await waitFor(() => expect(onAuth).toHaveBeenCalledWith('my-token'));
+  });
+
+  test('shows error message on failed login', async () => {
+    (auth.login as jest.Mock).mockRejectedValueOnce(new Error('Invalid credentials'));
+    render(<AuthForm onAuth={onAuth} />);
+    fireEvent.change(screen.getByPlaceholderText('Username'), { target: { value: 'alice' } });
+    fireEvent.change(screen.getByPlaceholderText('Password'), { target: { value: 'wrongpass' } });
+    await act(async () => {
+      fireEvent.submit(screen.getByRole('button', { name: /log in/i }).closest('form')!);
+    });
+    await waitFor(() => expect(screen.getByText('Invalid credentials')).toBeInTheDocument());
+    expect(onAuth).not.toHaveBeenCalled();
+  });
+
+  test('calls onAuth with token on successful register', async () => {
+    (auth.register as jest.Mock).mockResolvedValueOnce('reg-token');
+    render(<AuthForm onAuth={onAuth} />);
+    fireEvent.click(screen.getByRole('button', { name: /switch to register/i }));
+    fireEvent.change(screen.getByPlaceholderText('Username'), { target: { value: 'alice' } });
+    fireEvent.change(screen.getByPlaceholderText('Password'), { target: { value: 'password123' } });
+    await act(async () => {
+      fireEvent.submit(screen.getByRole('button', { name: /register/i }).closest('form')!);
+    });
+    await waitFor(() => expect(onAuth).toHaveBeenCalledWith('reg-token'));
+  });
+});

--- a/frontend/src/components/AuthForm.tsx
+++ b/frontend/src/components/AuthForm.tsx
@@ -1,0 +1,64 @@
+import React, { useState } from 'react';
+import { login, register } from '../services/auth';
+
+interface AuthFormProps {
+  onAuth: (token: string) => void;
+}
+
+const AuthForm: React.FC<AuthFormProps> = ({ onAuth }) => {
+  const [mode, setMode] = useState<'login' | 'register'>('login');
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setLoading(true);
+    try {
+      const token = mode === 'login'
+        ? await login(username, password)
+        : await register(username, password);
+      onAuth(token);
+    } catch (err: any) {
+      setError(err.message || 'Something went wrong');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="auth-container">
+      <h2>{mode === 'login' ? 'Log In' : 'Register'}</h2>
+      <form onSubmit={handleSubmit}>
+        <input
+          type="text"
+          placeholder="Username"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+          required
+        />
+        <input
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+        />
+        <button type="submit" disabled={loading}>
+          {loading ? 'Loading...' : mode === 'login' ? 'Log In' : 'Register'}
+        </button>
+      </form>
+      {error && <p style={{ color: 'red' }}>{error}</p>}
+      <button
+        type="button"
+        onClick={() => { setMode(mode === 'login' ? 'register' : 'login'); setError(null); }}
+      >
+        {mode === 'login' ? 'Switch to Register' : 'Switch to Login'}
+      </button>
+    </div>
+  );
+};
+
+export default AuthForm;

--- a/frontend/src/components/AuthForm.tsx
+++ b/frontend/src/components/AuthForm.tsx
@@ -31,7 +31,7 @@ const AuthForm: React.FC<AuthFormProps> = ({ onAuth }) => {
   return (
     <div className="auth-container">
       <h2>{mode === 'login' ? 'Log In' : 'Register'}</h2>
-      <form onSubmit={handleSubmit}>
+      <form className="auth-form" onSubmit={handleSubmit}>
         <input
           type="text"
           placeholder="Username"
@@ -50,8 +50,9 @@ const AuthForm: React.FC<AuthFormProps> = ({ onAuth }) => {
           {loading ? 'Loading...' : mode === 'login' ? 'Log In' : 'Register'}
         </button>
       </form>
-      {error && <p style={{ color: 'red' }}>{error}</p>}
+      {error && <p className="auth-error">{error}</p>}
       <button
+        className="auth-switch-btn"
         type="button"
         onClick={() => { setMode(mode === 'login' ? 'register' : 'login'); setError(null); }}
       >

--- a/frontend/src/services/api.test.ts
+++ b/frontend/src/services/api.test.ts
@@ -12,68 +12,90 @@ const mockTodo = {
   type: 'todo',
 };
 
+const TOKEN = 'test-token';
+const AUTH_HEADER = { Authorization: `Bearer ${TOKEN}` };
+
 beforeEach(() => mockFetch.mockClear());
 
 describe('getTodos', () => {
-  test('calls GET /todos and returns parsed JSON', async () => {
-    mockFetch.mockResolvedValueOnce({ ok: true, json: async () => [mockTodo] });
-    const result = await getTodos();
-    expect(mockFetch).toHaveBeenCalledWith('http://127.0.0.1:8000/todos');
+  test('calls GET /todos with Authorization header and returns parsed JSON', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true, status: 200, json: async () => [mockTodo] });
+    const result = await getTodos(TOKEN);
+    expect(mockFetch).toHaveBeenCalledWith('http://127.0.0.1:8000/todos', {
+      headers: AUTH_HEADER,
+    });
     expect(result).toEqual([mockTodo]);
   });
 
+  test('calls onUnauthorized and throws on 401', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 401 });
+    const onUnauthorized = jest.fn();
+    await expect(getTodos(TOKEN, onUnauthorized)).rejects.toThrow('Failed to fetch todos');
+    expect(onUnauthorized).toHaveBeenCalled();
+  });
+
   test('throws on non-ok response', async () => {
-    mockFetch.mockResolvedValueOnce({ ok: false });
-    await expect(getTodos()).rejects.toThrow('Failed to fetch todos');
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 500 });
+    await expect(getTodos(TOKEN)).rejects.toThrow('Failed to fetch todos');
   });
 });
 
 describe('addTodo', () => {
-  test('calls POST /todos with correct body and headers and returns created todo', async () => {
-    mockFetch.mockResolvedValueOnce({ ok: true, json: async () => mockTodo });
-    const result = await addTodo('Test');
+  test('calls POST /todos with Authorization header and returns created todo', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true, status: 201, json: async () => mockTodo });
+    const result = await addTodo('Test', TOKEN);
     expect(mockFetch).toHaveBeenCalledWith('http://127.0.0.1:8000/todos', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...AUTH_HEADER },
       body: JSON.stringify({ title: 'Test' }),
     });
     expect(result).toEqual(mockTodo);
   });
 
   test('throws on non-ok response', async () => {
-    mockFetch.mockResolvedValueOnce({ ok: false });
-    await expect(addTodo('Test')).rejects.toThrow('Failed to add todo');
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 500 });
+    await expect(addTodo('Test', TOKEN)).rejects.toThrow('Failed to add todo');
   });
 });
 
 describe('updateTodo', () => {
-  test('calls PUT /todos/{id} with correct body and returns updated todo', async () => {
+  test('calls PUT /todos/{id} with Authorization header and returns updated todo', async () => {
     const updated = { ...mockTodo, completed: true };
-    mockFetch.mockResolvedValueOnce({ ok: true, json: async () => updated });
-    const result = await updateTodo(1, { completed: true });
+    mockFetch.mockResolvedValueOnce({ ok: true, status: 200, json: async () => updated });
+    const result = await updateTodo(1, { completed: true }, TOKEN);
     expect(mockFetch).toHaveBeenCalledWith('http://127.0.0.1:8000/todos/1', {
       method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...AUTH_HEADER },
       body: JSON.stringify({ completed: true }),
     });
     expect(result).toEqual(updated);
   });
 
   test('throws on non-ok response', async () => {
-    mockFetch.mockResolvedValueOnce({ ok: false });
-    await expect(updateTodo(1, { completed: true })).rejects.toThrow('Failed to update todo');
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 500 });
+    await expect(updateTodo(1, { completed: true }, TOKEN)).rejects.toThrow('Failed to update todo');
   });
 });
 
 describe('deleteTodo', () => {
-  test('calls DELETE /todos/{id}', async () => {
-    mockFetch.mockResolvedValueOnce({ ok: true });
-    await deleteTodo(1);
-    expect(mockFetch).toHaveBeenCalledWith('http://127.0.0.1:8000/todos/1', { method: 'DELETE' });
+  test('calls DELETE /todos/{id} with Authorization header', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true, status: 204 });
+    await deleteTodo(1, TOKEN);
+    expect(mockFetch).toHaveBeenCalledWith('http://127.0.0.1:8000/todos/1', {
+      method: 'DELETE',
+      headers: AUTH_HEADER,
+    });
+  });
+
+  test('calls onUnauthorized and throws on 401', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 401 });
+    const onUnauthorized = jest.fn();
+    await expect(deleteTodo(1, TOKEN, onUnauthorized)).rejects.toThrow('Failed to delete todo');
+    expect(onUnauthorized).toHaveBeenCalled();
   });
 
   test('throws on non-ok response', async () => {
-    mockFetch.mockResolvedValueOnce({ ok: false });
-    await expect(deleteTodo(1)).rejects.toThrow('Failed to delete todo');
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 500 });
+    await expect(deleteTodo(1, TOKEN)).rejects.toThrow('Failed to delete todo');
   });
 });

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,48 +1,71 @@
 import { Todo } from '../types/todo';
 
-// Replace with your FastAPI server's URL
 const API_URL = 'http://127.0.0.1:8000';
 
-export const getTodos = async (): Promise<Todo[]> => {
-  const response = await fetch(`${API_URL}/todos`);
+const authHeaders = (token: string) => ({
+  'Authorization': `Bearer ${token}`,
+});
+
+export const getTodos = async (token: string, onUnauthorized?: () => void): Promise<Todo[]> => {
+  const response = await fetch(`${API_URL}/todos`, {
+    headers: authHeaders(token),
+  });
+  if (response.status === 401) {
+    onUnauthorized?.();
+    throw new Error('Failed to fetch todos');
+  }
   if (!response.ok) {
     throw new Error('Failed to fetch todos');
   }
   return await response.json();
 };
 
-export const addTodo = async (text: string): Promise<Todo> => {
+export const addTodo = async (text: string, token: string, onUnauthorized?: () => void): Promise<Todo> => {
   const response = await fetch(`${API_URL}/todos`, {
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
+    headers: { 'Content-Type': 'application/json', ...authHeaders(token) },
     body: JSON.stringify({ title: text }),
   });
+  if (response.status === 401) {
+    onUnauthorized?.();
+    throw new Error('Failed to add todo');
+  }
   if (!response.ok) {
     throw new Error('Failed to add todo');
   }
   return await response.json();
 };
 
-export const updateTodo = async (id: number, updatedFields: Partial<Pick<Todo, 'title' | 'completed'>>): Promise<Todo> => {
+export const updateTodo = async (
+  id: number,
+  updatedFields: Partial<Pick<Todo, 'title' | 'completed'>>,
+  token: string,
+  onUnauthorized?: () => void,
+): Promise<Todo> => {
   const response = await fetch(`${API_URL}/todos/${id}`, {
     method: 'PUT',
-    headers: {
-      'Content-Type': 'application/json',
-    },
+    headers: { 'Content-Type': 'application/json', ...authHeaders(token) },
     body: JSON.stringify(updatedFields),
   });
+  if (response.status === 401) {
+    onUnauthorized?.();
+    throw new Error('Failed to update todo');
+  }
   if (!response.ok) {
     throw new Error('Failed to update todo');
   }
   return await response.json();
 };
 
-export const deleteTodo = async (id: number): Promise<void> => {
+export const deleteTodo = async (id: number, token: string, onUnauthorized?: () => void): Promise<void> => {
   const response = await fetch(`${API_URL}/todos/${id}`, {
     method: 'DELETE',
+    headers: authHeaders(token),
   });
+  if (response.status === 401) {
+    onUnauthorized?.();
+    throw new Error('Failed to delete todo');
+  }
   if (!response.ok) {
     throw new Error('Failed to delete todo');
   }

--- a/frontend/src/services/auth.ts
+++ b/frontend/src/services/auth.ts
@@ -1,0 +1,30 @@
+const API_URL = 'http://127.0.0.1:8000';
+
+export const register = async (username: string, password: string): Promise<string> => {
+  const response = await fetch(`${API_URL}/auth/register`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username, password }),
+  });
+  if (!response.ok) {
+    const error = await response.json();
+    throw new Error(error.detail || 'Registration failed');
+  }
+  const data = await response.json();
+  return data.access_token;
+};
+
+export const login = async (username: string, password: string): Promise<string> => {
+  const body = new URLSearchParams({ username, password });
+  const response = await fetch(`${API_URL}/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: body.toString(),
+  });
+  if (!response.ok) {
+    const error = await response.json();
+    throw new Error(error.detail || 'Login failed');
+  }
+  const data = await response.json();
+  return data.access_token;
+};

--- a/frontend/src/services/auth.ts
+++ b/frontend/src/services/auth.ts
@@ -1,5 +1,11 @@
 const API_URL = 'http://127.0.0.1:8000';
 
+const extractDetail = (detail: any, fallback: string): string => {
+  if (!detail) return fallback;
+  if (Array.isArray(detail)) return detail.map((e: any) => e.msg).join(', ');
+  return String(detail);
+};
+
 export const register = async (username: string, password: string): Promise<string> => {
   const response = await fetch(`${API_URL}/auth/register`, {
     method: 'POST',
@@ -8,7 +14,7 @@ export const register = async (username: string, password: string): Promise<stri
   });
   if (!response.ok) {
     const error = await response.json();
-    throw new Error(error.detail || 'Registration failed');
+    throw new Error(extractDetail(error.detail, 'Registration failed'));
   }
   const data = await response.json();
   return data.access_token;
@@ -23,7 +29,7 @@ export const login = async (username: string, password: string): Promise<string>
   });
   if (!response.ok) {
     const error = await response.json();
-    throw new Error(error.detail || 'Login failed');
+    throw new Error(extractDetail(error.detail, 'Login failed'));
   }
   const data = await response.json();
   return data.access_token;


### PR DESCRIPTION
## Summary

- Add JWT-based registration and login (`POST /auth/register`, `POST /auth/login`) using PyJWT + passlib[bcrypt]
- Protect all `/todos` endpoints with Bearer token auth; todos are scoped per-user (users only see and manage their own data)
- Add frontend auth gate: login/register form before todo UI, logout button, automatic re-login on 401

## Test Plan

- [ ] Backend: `docker compose run --rm backend python -m pytest tests/ -v` — 30 tests pass (9 model, 13 CRUD endpoint, 8 auth)
- [ ] Frontend: `cd frontend && npm test -- --watchAll=false` — 42 tests pass across 7 suites
- [ ] End-to-end: `docker compose up -d`, open `http://localhost:3000`, register a user, create todos, log out, log back in — todos persist; a second user sees an empty list

🤖 Generated with [Claude Code](https://claude.com/claude-code)