### PR TITLE
feat: add Playwright e2e testing framework

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,52 @@
+# .github/workflows/e2e.yml
+name: E2E Tests
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  schedule:
+    - cron: '0 2 * * *'  # nightly at 02:00 UTC
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install e2e dependencies
+        run: npm ci
+        working-directory: e2e
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+        working-directory: e2e
+
+      - name: Start e2e stack
+        run: docker compose -f docker-compose.e2e.yml up -d
+
+      - name: Run smoke tests (PRs)
+        if: github.event_name == 'pull_request'
+        run: npx playwright test --grep @smoke
+        working-directory: e2e
+
+      - name: Run full suite (main / nightly)
+        if: github.event_name != 'pull_request'
+        run: npx playwright test
+        working-directory: e2e
+
+      - name: Tear down stack
+        if: always()
+        run: docker compose -f docker-compose.e2e.yml down -v
+
+      - name: Upload Playwright report on failure
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: playwright-report
+          path: e2e/playwright-report/
+          retention-days: 7

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -1,0 +1,54 @@
+# docker-compose.e2e.yml
+services:
+  postgres_e2e:
+    image: postgres:13
+    environment:
+      - POSTGRES_USER=user
+      - POSTGRES_PASSWORD=password
+      - POSTGRES_DB=tododb_e2e
+    volumes:
+      - postgres_e2e_data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U user -d tododb_e2e"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+  backend_e2e:
+    build:
+      context: ./backend
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./backend:/app
+    environment:
+      - PYTHONUNBUFFERED=1
+      - PYTHONPATH=/app
+      - DATABASE_URL=postgresql+asyncpg://user:password@postgres_e2e/tododb_e2e
+      - SECRET_KEY=e2e-test-secret-key
+    depends_on:
+      postgres_e2e:
+        condition: service_healthy
+    restart: unless-stopped
+
+  frontend_e2e:
+    build:
+      context: ./frontend
+      target: development
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./frontend:/app
+      - /app/node_modules
+    environment:
+      - CHOKIDAR_USEPOLLING=true
+      - REACT_APP_TIMELINE_FEATURE_FLAG=true
+    command: npm start
+    depends_on:
+      - backend_e2e
+
+volumes:
+  postgres_e2e_data:

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -1,4 +1,7 @@
 # docker-compose.e2e.yml
+
+# NOTE: This stack uses the same host ports as docker-compose.yml (3000, 8000, 5432).
+# Stop the dev stack first before starting this one: docker compose down
 services:
   postgres_e2e:
     image: postgres:13

--- a/docs/superpowers/plans/2026-03-23-e2e-framework.md
+++ b/docs/superpowers/plans/2026-03-23-e2e-framework.md
@@ -1,0 +1,1083 @@
+# E2E Testing Framework Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a Playwright TypeScript e2e test suite to the monorepo covering auth, todo CRUD, and timeline flows, running against an isolated Docker Compose stack in both CI and locally.
+
+**Architecture:** Page Object Model with two page classes (`AuthPage`, `TodoPage`) and two fixtures (`auth.fixture` for storageState reuse, `api.fixture` for direct API seeding). A `global-setup.ts` handles health-check polling and saves a logged-in browser state once before the suite runs. Tests live in `e2e/` at the repo root and run against `docker-compose.e2e.yml`, which has its own isolated PostgreSQL volume.
+
+**Tech Stack:** `@playwright/test` ^1.40, TypeScript 5, Node 20, Docker Compose, GitHub Actions
+
+---
+
+## File Map
+
+| Action | Path | Responsibility |
+|---|---|---|
+| Modify | `frontend/src/App.tsx` | Forward `type` arg from TodoForm; persist token in sessionStorage |
+| Modify | `frontend/src/services/api.ts` | Include `type` in `addTodo` request body |
+| Modify | `frontend/src/services/api.test.ts` | Update `addTodo` body assertion to include `type: 'todo'` |
+| Modify | `frontend/src/App.test.tsx` | Add `sessionStorage.clear()` in `beforeEach` for isolation |
+| Create | `docker-compose.e2e.yml` | Isolated test stack with separate PostgreSQL volume |
+| Create | `e2e/package.json` | e2e project dependencies |
+| Create | `e2e/tsconfig.json` | TypeScript config for e2e project |
+| Create | `e2e/playwright.config.ts` | Playwright configuration |
+| Create | `e2e/test-constants.ts` | Shared test credentials and URLs |
+| Create | `e2e/global-setup.ts` | Health checks + save logged-in storageState |
+| Create | `e2e/pages/AuthPage.ts` | Page object for login/register UI |
+| Create | `e2e/pages/TodoPage.ts` | Page object for todo list, form, timeline tab |
+| Create | `e2e/fixtures/auth.fixture.ts` | `test.extend` fixture loading saved storageState |
+| Create | `e2e/fixtures/api.fixture.ts` | Direct HTTP calls for data seeding and cleanup |
+| Create | `e2e/tests/auth.spec.ts` | Auth test scenarios |
+| Create | `e2e/tests/todos.spec.ts` | Todo CRUD test scenarios |
+| Create | `e2e/tests/timeline.spec.ts` | Timeline tab test scenarios |
+| Create | `e2e/.gitignore` | Ignore `.auth/`, `node_modules/`, `playwright-report/`, `test-results/` |
+| Create | `.github/workflows/e2e.yml` | CI workflow |
+
+---
+
+## Task 1: Fix App.tsx — forward `type` from TodoForm + sessionStorage token persistence
+
+**Why:** `App.tsx`'s `addTodo` currently ignores the `type` argument from `TodoForm`, so timeline items are always saved as `type: "todo"`. Also, the token lives only in React state — Playwright's `storageState` can only persist cookies/localStorage/sessionStorage, so we add sessionStorage persistence to enable session reuse across tests.
+
+> **Note:** `App.tsx` already has a pre-existing TypeScript mismatch — `addTodo` is declared as `(text: string)` but `TodoForm` passes `(text, type)`. `react-scripts test` uses Babel (transpiles without type-checking), so existing unit tests pass despite the error. After this task is applied, the mismatch is fixed. Running `tsc --noEmit` from `frontend/` will show the current error before the fix.
+
+**Files:**
+- Modify: `frontend/src/App.tsx`
+- Modify: `frontend/src/App.test.tsx`
+
+- [ ] **Step 1: Update `App.tsx`**
+
+Replace the token state initialization, `handleUnauthorized`, the logout button handler, the `onAuth` prop, and the `addTodo` function:
+
+```tsx
+// Line 14 — initialize token from sessionStorage
+const [token, setToken] = useState<string | null>(sessionStorage.getItem('token'));
+
+// Replace handleUnauthorized (line 18)
+const handleUnauthorized = () => {
+  sessionStorage.removeItem('token');
+  setToken(null);
+};
+
+// Add handleAuth (after handleUnauthorized)
+const handleAuth = (t: string) => {
+  sessionStorage.setItem('token', t);
+  setToken(t);
+};
+
+// Replace addTodo signature (line 38) — accept type from TodoForm
+const addTodo = async (text: string, type: string = 'todo') => {
+  if (!token) return;
+  try {
+    const newTodo = await api.addTodo(text, token, handleUnauthorized, type);
+    setTodos((prevTodos) => [...prevTodos, newTodo]);
+  } catch (err) {
+    setError('Failed to add todo.');
+    console.error(err);
+  }
+};
+
+// Replace logout button onClick (line 95)
+onClick={() => { sessionStorage.removeItem('token'); setToken(null); }}
+
+// Replace onAuth prop on AuthForm (line 77)
+<AuthForm onAuth={handleAuth} />
+```
+
+- [ ] **Step 2: Add `sessionStorage.clear()` to `App.test.tsx` `beforeEach`**
+
+In `App.test.tsx`, inside the existing `beforeEach`:
+```ts
+beforeEach(() => {
+  jest.clearAllMocks();
+  sessionStorage.clear(); // prevent token bleed-through between tests
+});
+```
+
+No other changes to `App.test.tsx` are required. The `handleAuth` wrapper still calls `setToken`, so mock-resolved logins continue to work. `sessionStorage.getItem('token')` returns `null` at the start of each test because of the `clear()` call above.
+
+- [ ] **Step 3: Run frontend unit tests to confirm nothing broke**
+
+```bash
+cd frontend && npm test -- --watchAll=false
+```
+Expected: all existing tests pass
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/App.tsx frontend/src/App.test.tsx
+git commit -m "fix: forward todo type from TodoForm and persist token in sessionStorage"
+```
+
+---
+
+## Task 2: Fix api.ts — include `type` in `addTodo` request body
+
+**Why:** `api.ts`'s `addTodo` sends `{ title: text }` only; the `type` field is never sent to the backend. The backend does accept and persist `type` when provided.
+
+**Files:**
+- Modify: `frontend/src/services/api.ts`
+- Modify: `frontend/src/services/api.test.ts`
+
+- [ ] **Step 1: Update `api.ts` — add `type` parameter and include it in the body**
+
+Change the `addTodo` signature to add `type` as the last optional param (after `onUnauthorized`) to avoid breaking existing callers:
+
+```ts
+// frontend/src/services/api.ts
+export const addTodo = async (
+  text: string,
+  token: string,
+  onUnauthorized?: () => void,
+  type: string = 'todo',
+): Promise<Todo> => {
+  const response = await fetch(`${API_URL}/todos`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...authHeaders(token) },
+    body: JSON.stringify({ title: text, type }),
+  });
+  if (response.status === 401) {
+    onUnauthorized?.();
+    throw new Error('Failed to add todo');
+  }
+  if (!response.ok) {
+    throw new Error('Failed to add todo');
+  }
+  return await response.json();
+};
+```
+
+- [ ] **Step 2: Update `api.test.ts` — fix body assertion**
+
+The test currently asserts `body: JSON.stringify({ title: 'Test' })`. Update it to include the default type:
+
+```ts
+// In the addTodo describe block, update the body assertion:
+body: JSON.stringify({ title: 'Test', type: 'todo' }),
+```
+
+- [ ] **Step 3: Run frontend unit tests**
+
+```bash
+cd frontend && npm test -- --watchAll=false
+```
+Expected: all tests pass
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/services/api.ts frontend/src/services/api.test.ts
+git commit -m "fix: include type field in addTodo API request body"
+```
+
+---
+
+## Task 3: Create `docker-compose.e2e.yml`
+
+**Files:**
+- Create: `docker-compose.e2e.yml`
+
+- [ ] **Step 1: Create the file**
+
+```yaml
+# docker-compose.e2e.yml
+services:
+  postgres_e2e:
+    image: postgres:13
+    environment:
+      - POSTGRES_USER=user
+      - POSTGRES_PASSWORD=password
+      - POSTGRES_DB=tododb_e2e
+    volumes:
+      - postgres_e2e_data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U user -d tododb_e2e"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+  backend_e2e:
+    build:
+      context: ./backend
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./backend:/app
+    environment:
+      - PYTHONUNBUFFERED=1
+      - PYTHONPATH=/app
+      - DATABASE_URL=postgresql+asyncpg://user:password@postgres_e2e/tododb_e2e
+      - SECRET_KEY=e2e-test-secret-key
+    depends_on:
+      postgres_e2e:
+        condition: service_healthy
+    restart: unless-stopped
+
+  frontend_e2e:
+    build:
+      context: ./frontend
+      target: development
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./frontend:/app
+      - /app/node_modules
+    environment:
+      - CHOKIDAR_USEPOLLING=true
+      - REACT_APP_TIMELINE_FEATURE_FLAG=true
+    command: npm start
+    depends_on:
+      - backend_e2e
+
+volumes:
+  postgres_e2e_data:
+```
+
+- [ ] **Step 2: Verify it starts cleanly**
+
+> **Port conflict warning:** both `docker-compose.yml` (dev) and `docker-compose.e2e.yml` bind ports `3000`, `8000`, and `5432` on the host. If the dev stack is running, stop it first: `docker compose down`
+
+```bash
+docker compose -f docker-compose.e2e.yml up -d
+docker compose -f docker-compose.e2e.yml ps
+```
+Expected: all three services show `running` or `healthy`
+
+- [ ] **Step 3: Tear down**
+
+```bash
+docker compose -f docker-compose.e2e.yml down -v
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docker-compose.e2e.yml
+git commit -m "feat: add docker-compose.e2e.yml with isolated postgres volume"
+```
+
+---
+
+## Task 4: Bootstrap e2e project
+
+**Files:**
+- Create: `e2e/package.json`
+- Create: `e2e/tsconfig.json`
+- Create: `e2e/playwright.config.ts`
+- Create: `e2e/test-constants.ts`
+- Create: `e2e/.gitignore`
+
+- [ ] **Step 1: Create `e2e/package.json`**
+
+```json
+{
+  "name": "todo-e2e",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "test": "playwright test",
+    "test:smoke": "playwright test --grep @smoke",
+    "test:headed": "playwright test --headed",
+    "report": "playwright show-report"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.40.0",
+    "typescript": "^5.0.0"
+  }
+}
+```
+
+- [ ] **Step 2: Create `e2e/tsconfig.json`**
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "baseUrl": "."
+  },
+  "include": ["./**/*.ts"],
+  "exclude": ["node_modules", "playwright-report", "test-results"]
+}
+```
+
+- [ ] **Step 3: Create `e2e/.gitignore`**
+
+```
+node_modules/
+playwright-report/
+test-results/
+.auth/
+```
+
+- [ ] **Step 4: Create `e2e/test-constants.ts`**
+
+Shared credentials and URLs used by `global-setup.ts` and `api.fixture.ts`:
+
+```ts
+// e2e/test-constants.ts
+export const TEST_USER = {
+  username: 'e2e-testuser',
+  password: 'e2e-password-42',
+};
+
+export const BACKEND_URL = 'http://localhost:8000';
+export const FRONTEND_URL = 'http://localhost:3000';
+```
+
+- [ ] **Step 5: Create `e2e/playwright.config.ts`**
+
+```ts
+// e2e/playwright.config.ts
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  globalSetup: './global-setup',
+  retries: process.env.CI ? 1 : 0,
+  reporter: [['html', { open: 'never' }], ['list']],
+  use: {
+    baseURL: 'http://localhost:3000',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});
+```
+
+- [ ] **Step 6: Install dependencies**
+
+```bash
+cd e2e && npm install && npx playwright install --with-deps chromium
+```
+Expected: `node_modules` created, Chromium browser downloaded
+
+- [ ] **Step 7: Commit (include `package-lock.json` — required for `npm ci` in CI)**
+
+```bash
+git add e2e/package.json e2e/package-lock.json e2e/tsconfig.json e2e/playwright.config.ts e2e/test-constants.ts e2e/.gitignore
+git commit -m "feat: bootstrap e2e project with Playwright config"
+```
+
+---
+
+## Task 5: Create `global-setup.ts`
+
+> **Prerequisite:** Task 1 must be complete before this task. `global-setup.ts` saves `storageState` which captures `sessionStorage`. The token is only written to `sessionStorage` after Task 1's changes to `App.tsx` are applied. Running this task against the unmodified `App.tsx` will save an empty `storageState` with no token, causing every auth-fixture test to land on the login screen. Confirm Task 1 is done first.
+
+**Why:** Runs once before the suite. Polls health endpoints until the stack is ready, then logs in via the UI (the only way to capture React state-based auth in `storageState`), and saves the browser session to `e2e/.auth/user.json`.
+
+**Files:**
+- Create: `e2e/global-setup.ts`
+
+- [ ] **Step 1: Create the file**
+
+```ts
+// e2e/global-setup.ts
+import { chromium, FullConfig } from '@playwright/test';
+import * as fs from 'fs';
+import * as path from 'path';
+import { TEST_USER, BACKEND_URL, FRONTEND_URL } from './test-constants';
+
+const AUTH_FILE = path.join(__dirname, '.auth/user.json');
+const POLL_INTERVAL_MS = 2000;
+const TIMEOUT_MS = 60_000;
+
+async function waitForService(url: string, label: string): Promise<void> {
+  const deadline = Date.now() + TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(url);
+      if (res.ok) {
+        console.log(`[global-setup] ${label} ready`);
+        return;
+      }
+    } catch {
+      // not ready yet — swallow and retry
+    }
+    await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+  }
+  throw new Error(`[global-setup] Timed out after ${TIMEOUT_MS}ms waiting for ${label} at ${url}`);
+}
+
+async function ensureTestUserExists(): Promise<void> {
+  // Register — ignore 409 if user already exists
+  await fetch(`${BACKEND_URL}/auth/register`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username: TEST_USER.username, password: TEST_USER.password }),
+  });
+}
+
+export default async function globalSetup(_config: FullConfig) {
+  // 1. Wait for both services to be healthy
+  await waitForService(`${BACKEND_URL}/`, 'backend');
+  await waitForService(FRONTEND_URL, 'frontend');
+
+  // 2. Ensure the test user exists in the DB
+  await ensureTestUserExists();
+
+  // 3. Log in via the UI and save storageState (captures sessionStorage with token)
+  fs.mkdirSync(path.dirname(AUTH_FILE), { recursive: true });
+
+  const browser = await chromium.launch();
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  await page.goto(FRONTEND_URL);
+  await page.getByPlaceholder('Username').fill(TEST_USER.username);
+  await page.getByPlaceholder('Password').fill(TEST_USER.password);
+  await page.getByRole('button', { name: 'Log In' }).click();
+
+  // Wait until past the auth gate
+  await page.getByPlaceholder('Add a new task...').waitFor({ timeout: 15_000 });
+
+  await context.storageState({ path: AUTH_FILE });
+  await browser.close();
+
+  console.log('[global-setup] storageState saved to', AUTH_FILE);
+}
+```
+
+- [ ] **Step 2: Start the stack and do a smoke run**
+
+```bash
+docker compose -f docker-compose.e2e.yml up -d
+cd e2e && npx playwright test --list
+```
+Expected: global-setup runs without error, test list is printed (even if 0 tests — they don't exist yet)
+
+- [ ] **Step 3: Tear down**
+
+```bash
+docker compose -f docker-compose.e2e.yml down -v
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add e2e/global-setup.ts
+git commit -m "feat: add global-setup with health polling and storageState login"
+```
+
+---
+
+## Task 6: Create page objects
+
+**Files:**
+- Create: `e2e/pages/AuthPage.ts`
+- Create: `e2e/pages/TodoPage.ts`
+
+- [ ] **Step 1: Create `e2e/pages/AuthPage.ts`**
+
+```ts
+// e2e/pages/AuthPage.ts
+import { Page, expect } from '@playwright/test';
+
+export class AuthPage {
+  constructor(private page: Page) {}
+
+  async login(username: string, password: string) {
+    await this.page.getByPlaceholder('Username').fill(username);
+    await this.page.getByPlaceholder('Password').fill(password);
+    await this.page.getByRole('button', { name: 'Log In' }).click();
+  }
+
+  async register(username: string, password: string) {
+    await this.page.getByRole('button', { name: 'Switch to Register' }).click();
+    await this.page.getByPlaceholder('Username').fill(username);
+    await this.page.getByPlaceholder('Password').fill(password);
+    await this.page.getByRole('button', { name: 'Register' }).click();
+  }
+
+  async expectError(message: string) {
+    await expect(this.page.locator('.auth-error')).toHaveText(message);
+  }
+
+  async expectTodoFormVisible() {
+    await expect(this.page.getByPlaceholder('Add a new task...')).toBeVisible();
+  }
+
+  async expectAuthFormVisible() {
+    await expect(this.page.getByPlaceholder('Username')).toBeVisible();
+  }
+}
+```
+
+- [ ] **Step 2: Create `e2e/pages/TodoPage.ts`**
+
+```ts
+// e2e/pages/TodoPage.ts
+import { Page, Locator, expect } from '@playwright/test';
+
+export class TodoPage {
+  constructor(private page: Page) {}
+
+  async addTodo(text: string, type: 'todo' | 'timeline' = 'todo') {
+    await this.page.getByPlaceholder('Add a new task...').fill(text);
+    // Select is always rendered; default is 'todo' — only change when needed
+    if (type === 'timeline') {
+      await this.page.getByRole('combobox').selectOption('timeline');
+    }
+    await this.page.getByRole('button', { name: 'Add' }).click();
+    // Reset select back to 'todo' for next call (avoids state leaking between actions)
+    if (type === 'timeline') {
+      await this.page.getByRole('combobox').selectOption('todo');
+    }
+  }
+
+  private todoRow(text: string): Locator {
+    return this.page.locator('.todo-item').filter({ hasText: text });
+  }
+
+  async toggleTodo(text: string) {
+    await this.todoRow(text).getByRole('checkbox').click();
+  }
+
+  async deleteTodo(text: string) {
+    await this.todoRow(text).getByRole('button', { name: 'Delete' }).click();
+  }
+
+  async expectTodoVisible(text: string) {
+    await expect(this.todoRow(text)).toBeVisible();
+  }
+
+  async expectTodoNotVisible(text: string) {
+    await expect(this.todoRow(text)).not.toBeVisible();
+  }
+
+  async expectCompleted(text: string) {
+    // The inline style 'text-decoration: line-through' is on the first child div of .todo-item
+    await expect(
+      this.todoRow(text).locator('> div:first-child'),
+    ).toHaveCSS('text-decoration', /line-through/);
+  }
+
+  async switchToTimeline() {
+    await this.page.getByRole('tab', { name: 'Timeline' }).click();
+  }
+
+  async expectTimelineTabVisible() {
+    await expect(this.page.getByRole('tab', { name: 'Timeline' })).toBeVisible();
+  }
+
+  async logout() {
+    await this.page.getByRole('button', { name: 'Logout' }).click();
+  }
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add e2e/pages/
+git commit -m "feat: add AuthPage and TodoPage page objects"
+```
+
+---
+
+## Task 7: Create fixtures
+
+**Files:**
+- Create: `e2e/fixtures/auth.fixture.ts`
+- Create: `e2e/fixtures/api.fixture.ts`
+
+- [ ] **Step 1: Create `e2e/fixtures/auth.fixture.ts`**
+
+```ts
+// e2e/fixtures/auth.fixture.ts
+import { test as base, BrowserContext, Page } from '@playwright/test';
+import * as path from 'path';
+
+const AUTH_FILE = path.join(__dirname, '../.auth/user.json');
+
+type AuthFixtures = {
+  authenticatedPage: Page;
+  authenticatedContext: BrowserContext;
+};
+
+export const test = base.extend<AuthFixtures>({
+  authenticatedContext: async ({ browser }, use) => {
+    const context = await browser.newContext({ storageState: AUTH_FILE });
+    await use(context);
+    await context.close();
+  },
+  authenticatedPage: async ({ authenticatedContext }, use) => {
+    const page = await authenticatedContext.newPage();
+    await use(page);
+    await page.close();
+  },
+});
+
+export { expect } from '@playwright/test';
+```
+
+- [ ] **Step 2: Create `e2e/fixtures/api.fixture.ts`**
+
+```ts
+// e2e/fixtures/api.fixture.ts
+import { TEST_USER, BACKEND_URL } from '../test-constants';
+
+interface TodoItem {
+  id: number;
+  title: string;
+  completed: boolean;
+  type: string;
+}
+
+export class ApiFixture {
+  private token: string | null = null;
+
+  private async getToken(): Promise<string> {
+    if (this.token) return this.token;
+
+    // /auth/login requires application/x-www-form-urlencoded (FastAPI OAuth2PasswordRequestForm)
+    const res = await fetch(`${BACKEND_URL}/auth/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        username: TEST_USER.username,
+        password: TEST_USER.password,
+      }),
+    });
+    if (!res.ok) throw new Error(`ApiFixture login failed: ${res.status}`);
+    const data = await res.json();
+    this.token = data.access_token;
+    return this.token!;
+  }
+
+  async createTodo(title: string, type: 'todo' | 'timeline' = 'todo'): Promise<TodoItem> {
+    const token = await this.getToken();
+    const res = await fetch(`${BACKEND_URL}/todos`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ title, type }),
+    });
+    if (!res.ok) throw new Error(`createTodo failed: ${res.status}`);
+    return res.json();
+  }
+
+  async clearTodos(): Promise<void> {
+    const token = await this.getToken();
+    // No bulk-delete endpoint — must list then delete individually
+    const res = await fetch(`${BACKEND_URL}/todos`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!res.ok) throw new Error(`clearTodos list failed: ${res.status}`);
+    const todos: TodoItem[] = await res.json();
+    for (const todo of todos) {
+      await fetch(`${BACKEND_URL}/todos/${todo.id}`, {
+        method: 'DELETE',
+        headers: { Authorization: `Bearer ${token}` },
+      });
+    }
+  }
+
+  async registerUser(username: string, password: string): Promise<string> {
+    // Returns JWT token for the new user
+    const res = await fetch(`${BACKEND_URL}/auth/register`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password }),
+    });
+    if (!res.ok) throw new Error(`registerUser failed: ${res.status}`);
+    const data = await res.json();
+    return data.access_token;
+  }
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add e2e/fixtures/
+git commit -m "feat: add auth and api fixtures"
+```
+
+---
+
+## Task 8: Write `auth.spec.ts`
+
+**Files:**
+- Create: `e2e/tests/auth.spec.ts`
+
+- [ ] **Step 1: Create the file**
+
+```ts
+// e2e/tests/auth.spec.ts
+import * as path from 'path';
+import { test, expect } from '@playwright/test';
+import { AuthPage } from '../pages/AuthPage';
+import { FRONTEND_URL } from '../test-constants';
+
+// Unique suffix per test run prevents username collisions when rerunning without DB wipe
+const runId = Date.now();
+
+test.describe('Authentication', () => {
+  test('@smoke register a new user and land on todo list', async ({ page }) => {
+    const auth = new AuthPage(page);
+    await page.goto(FRONTEND_URL);
+    await auth.register(`newuser-${runId}`, 'password123');
+    await auth.expectTodoFormVisible();
+  });
+
+  test('@smoke login with valid credentials', async ({ page }) => {
+    const auth = new AuthPage(page);
+    await page.goto(FRONTEND_URL);
+    // Use the pre-created e2e test user (exists from global-setup)
+    await auth.login('e2e-testuser', 'e2e-password-42');
+    await auth.expectTodoFormVisible();
+  });
+
+  test('login with wrong password shows error', async ({ page }) => {
+    const auth = new AuthPage(page);
+    await page.goto(FRONTEND_URL);
+    await auth.login('e2e-testuser', 'wrongpassword');
+    await auth.expectError('Invalid credentials');
+  });
+
+  test('logout returns to login screen', async ({ page }) => {
+    // Log in first
+    const auth = new AuthPage(page);
+    await page.goto(FRONTEND_URL);
+    await auth.login('e2e-testuser', 'e2e-password-42');
+    await auth.expectTodoFormVisible();
+
+    // Log out
+    const { TodoPage } = await import('../pages/TodoPage');
+    const todo = new TodoPage(page);
+    await todo.logout();
+    await auth.expectAuthFormVisible();
+  });
+
+  test('401 from API clears session and shows login screen', async ({ browser }) => {
+    // Start authenticated
+    const context = await browser.newContext({
+      storageState: path.join(__dirname, '../.auth/user.json'),
+    });
+    const page = await context.newPage();
+    const auth = new AuthPage(page);
+
+    await page.goto(FRONTEND_URL);
+    await auth.expectTodoFormVisible();
+
+    // Simulate 401 by clearing sessionStorage (mimics token expiry without waiting)
+    await page.evaluate(() => sessionStorage.clear());
+    await page.reload();
+
+    // App re-reads token from sessionStorage on mount — it is now null
+    await auth.expectAuthFormVisible();
+
+    await context.close();
+  });
+});
+```
+
+- [ ] **Step 2: Start the stack and run auth tests**
+
+```bash
+docker compose -f docker-compose.e2e.yml up -d
+cd e2e && npx playwright test tests/auth.spec.ts --reporter=list
+```
+Expected: all 5 auth tests pass
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add e2e/tests/auth.spec.ts
+git commit -m "feat: add auth e2e tests"
+```
+
+---
+
+## Task 9: Write `todos.spec.ts`
+
+**Files:**
+- Create: `e2e/tests/todos.spec.ts`
+
+- [ ] **Step 1: Create the file**
+
+```ts
+// e2e/tests/todos.spec.ts
+import { test, expect } from '../fixtures/auth.fixture';
+import { TodoPage } from '../pages/TodoPage';
+import { ApiFixture } from '../fixtures/api.fixture';
+import { FRONTEND_URL, BACKEND_URL } from '../test-constants';
+
+const api = new ApiFixture();
+
+test.describe('Todo CRUD', () => {
+  test.afterEach(async () => {
+    await api.clearTodos();
+  });
+
+  test('@smoke add a todo and see it in the list', async ({ authenticatedPage }) => {
+    const todo = new TodoPage(authenticatedPage);
+    await authenticatedPage.goto(FRONTEND_URL);
+
+    await todo.addTodo('Buy milk');
+    await todo.expectTodoVisible('Buy milk');
+  });
+
+  test('@smoke complete a todo — checkbox checked and text struck through', async ({ authenticatedPage }) => {
+    await api.createTodo('Read a book');
+    const todo = new TodoPage(authenticatedPage);
+    await authenticatedPage.goto(FRONTEND_URL);
+
+    await todo.toggleTodo('Read a book');
+    await todo.expectCompleted('Read a book');
+  });
+
+  test('@smoke delete a todo — removed from list', async ({ authenticatedPage }) => {
+    await api.createTodo('Take out trash');
+    const todo = new TodoPage(authenticatedPage);
+    await authenticatedPage.goto(FRONTEND_URL);
+
+    await todo.deleteTodo('Take out trash');
+    await todo.expectTodoNotVisible('Take out trash');
+  });
+
+  test('delete one todo while others remain', async ({ authenticatedPage }) => {
+    await api.createTodo('Task A');
+    await api.createTodo('Task B');
+    const todo = new TodoPage(authenticatedPage);
+    await authenticatedPage.goto(FRONTEND_URL);
+
+    await todo.deleteTodo('Task A');
+    await todo.expectTodoNotVisible('Task A');
+    await todo.expectTodoVisible('Task B');
+  });
+
+  test('User A todos are not visible to User B', async ({ browser }) => {
+    // User A already has todos (seeded via API)
+    await api.createTodo('User A secret todo');
+
+    // Register User B (unique username per run)
+    const runId = Date.now();
+    const userBToken = await api.registerUser(`user-b-${runId}`, 'passwordB');
+
+    // Log in as User B via a fresh browser context (no storageState)
+    const contextB = await browser.newContext();
+    const pageB = await contextB.newPage();
+
+    // Log in via the backend directly and inject sessionStorage
+    await pageB.goto(FRONTEND_URL);
+    await pageB.getByPlaceholder('Username').fill(`user-b-${runId}`);
+    await pageB.getByPlaceholder('Password').fill('passwordB');
+    await pageB.getByRole('button', { name: 'Log In' }).click();
+    await pageB.getByPlaceholder('Add a new task...').waitFor();
+
+    // User A's todo must not appear in User B's view
+    await expect(pageB.locator('.todo-item')).toHaveCount(0);
+
+    await contextB.close();
+  });
+});
+```
+
+- [ ] **Step 2: Run todo tests**
+
+```bash
+cd e2e && npx playwright test tests/todos.spec.ts --reporter=list
+```
+Expected: all 5 todo tests pass
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add e2e/tests/todos.spec.ts
+git commit -m "feat: add todo CRUD e2e tests"
+```
+
+---
+
+## Task 10: Write `timeline.spec.ts`
+
+**Files:**
+- Create: `e2e/tests/timeline.spec.ts`
+
+- [ ] **Step 1: Create the file**
+
+```ts
+// e2e/tests/timeline.spec.ts
+import { test, expect } from '../fixtures/auth.fixture';
+import { TodoPage } from '../pages/TodoPage';
+import { ApiFixture } from '../fixtures/api.fixture';
+import { FRONTEND_URL } from '../test-constants';
+
+const api = new ApiFixture();
+
+test.describe('Timeline tab', () => {
+  test.afterEach(async () => {
+    await api.clearTodos();
+  });
+
+  test('Timeline tab is visible when feature flag is on', async ({ authenticatedPage }) => {
+    const todo = new TodoPage(authenticatedPage);
+    await authenticatedPage.goto(FRONTEND_URL);
+    await todo.expectTimelineTabVisible();
+  });
+
+  test('timeline item appears in Timeline tab and not in To-Do tab', async ({ authenticatedPage }) => {
+    const todo = new TodoPage(authenticatedPage);
+    await authenticatedPage.goto(FRONTEND_URL);
+
+    await todo.addTodo('Q3 milestone', 'timeline');
+
+    // Item must NOT appear in To-Do tab (current tab)
+    await todo.expectTodoNotVisible('Q3 milestone');
+
+    // Item MUST appear in Timeline tab
+    await todo.switchToTimeline();
+    await expect(authenticatedPage.getByText('Q3 milestone')).toBeVisible();
+  });
+});
+```
+
+- [ ] **Step 2: Run timeline tests**
+
+```bash
+cd e2e && npx playwright test tests/timeline.spec.ts --reporter=list
+```
+Expected: both tests pass
+
+- [ ] **Step 3: Tear down stack**
+
+```bash
+docker compose -f docker-compose.e2e.yml down -v
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add e2e/tests/timeline.spec.ts
+git commit -m "feat: add timeline tab e2e tests"
+```
+
+---
+
+## Task 11: Create GitHub Actions CI workflow
+
+**Files:**
+- Create: `.github/workflows/e2e.yml`
+
+- [ ] **Step 1: Create the file**
+
+```yaml
+# .github/workflows/e2e.yml
+name: E2E Tests
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  schedule:
+    - cron: '0 2 * * *'  # nightly at 02:00 UTC
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install e2e dependencies
+        run: npm ci
+        working-directory: e2e
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+        working-directory: e2e
+
+      - name: Start e2e stack
+        run: docker compose -f docker-compose.e2e.yml up -d
+
+      - name: Run smoke tests (PRs)
+        if: github.event_name == 'pull_request'
+        run: npx playwright test --grep @smoke
+        working-directory: e2e
+
+      - name: Run full suite (main / nightly)
+        if: github.event_name != 'pull_request'
+        run: npx playwright test
+        working-directory: e2e
+
+      - name: Tear down stack
+        if: always()
+        run: docker compose -f docker-compose.e2e.yml down -v
+
+      - name: Upload Playwright report on failure
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: playwright-report
+          path: e2e/playwright-report/
+          retention-days: 7
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .github/workflows/e2e.yml
+git commit -m "ci: add GitHub Actions e2e workflow with smoke/full split"
+```
+
+---
+
+## Task 12: Full suite verification
+
+- [ ] **Step 1: Start the e2e stack**
+
+```bash
+docker compose -f docker-compose.e2e.yml up -d
+```
+
+- [ ] **Step 2: Run smoke tests**
+
+```bash
+cd e2e && npx playwright test --grep @smoke --reporter=list
+```
+Expected: 5 smoke-tagged tests all pass (2 auth + 3 todos)
+
+- [ ] **Step 3: Run full suite**
+
+```bash
+cd e2e && npx playwright test --reporter=list
+```
+Expected: all 12 tests pass, 0 failures
+
+- [ ] **Step 4: Run frontend unit tests to confirm no regression**
+
+```bash
+cd ../frontend && npm test -- --watchAll=false
+```
+Expected: all existing unit tests pass
+
+- [ ] **Step 5: Tear down**
+
+```bash
+docker compose -f docker-compose.e2e.yml down -v
+```
+
+- [ ] **Step 6: Final commit (if any cleanup needed)**
+
+```bash
+git status  # should be clean after previous task commits
+```

--- a/docs/superpowers/plans/2026-03-23-performance-testing-framework.md
+++ b/docs/superpowers/plans/2026-03-23-performance-testing-framework.md
@@ -1,0 +1,890 @@
+# Performance Testing Framework Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a k6-based performance testing framework inside `/performance/` that provides CI regression gates (smoke test) and on-demand capacity profiling (load, stress, soak, spike scenarios).
+
+**Architecture:** Shared libraries (`lib/`) handle auth, HTTP client, and data generation. Scenario scripts (`scenarios/`) import from `lib/` and embed CI/local thresholds via `__ENV.CI`. A dedicated `docker-compose.perf.yml` spins up an isolated `postgres_perf` + `backend_perf` stack. GitHub Actions runs smoke on every PR to main.
+
+**Tech Stack:** k6 v0.54.0, grafana/k6:0.54.0 Docker image, Docker Compose, GitHub Actions, FastAPI backend (JWT auth, PostgreSQL)
+
+---
+
+## Pre-flight: Key constraints to know
+
+- **k6 init stage prohibits HTTP** — all network calls must be inside `default()` or `teardown()`
+- **`/auth/login` uses form encoding** (`application/x-www-form-urlencoded`), not JSON — FastAPI's `OAuth2PasswordRequestForm`
+- **`/auth/register` returns 409** when username already exists — `lib/auth.js` must handle this for repeated local runs
+- **`ACCESS_TOKEN_EXPIRE_MINUTES=30`** by default — override to `120` in `docker-compose.perf.yml` so soak test tokens don't expire mid-run
+- **k6 built-ins:** `__VU` = VU ID (1-indexed), `__ITER` = iteration counter per VU (0-indexed)
+- **Auth pattern:** module-level `let token = null` guard — if null on entry to `default()`, register + login, store in module var
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `performance/lib/auth.js` | Create | registerAndLogin with 409 handling; returns JWT token |
+| `performance/lib/client.js` | Create | HTTP wrapper with Authorization header pre-set |
+| `performance/lib/data.js` | Create | Deterministic todo payload generator |
+| `performance/scenarios/smoke.js` | Create | 1 VU, 30s, all endpoints, checks + thresholds |
+| `performance/scenarios/load.js` | Create | Ramp 1→50→0 VUs, 5min |
+| `performance/scenarios/stress.js` | Create | Ramp 1→200→0 VUs, 10min |
+| `performance/scenarios/soak.js` | Create | 20 VUs steady, 30min |
+| `performance/scenarios/spike.js` | Create | 0→500→0 VUs, 2min |
+| `performance/docker-compose.perf.yml` | Create | Dedicated perf stack: postgres_perf + backend_perf + k6 |
+| `performance/run.sh` | Create | Local runner: ./run.sh <scenario> [BASE_URL] |
+| `performance/README.md` | Create | Usage docs, resource warnings, volume pruning instructions |
+| `.github/workflows/perf.yml` | Create | CI: smoke on PR to main + push to main |
+| `performance/reports/.gitkeep` | Create | Ensure reports dir exists but contents are gitignored |
+| `performance/.gitignore` | Create | Ignore reports/*.json and reports/*.html |
+
+---
+
+## Task 1: Scaffold directory and git setup
+
+**Files:**
+- Create: `performance/.gitignore`
+- Create: `performance/reports/.gitkeep`
+- Create: `performance/lib/.gitkeep` (placeholder, removed when real files added)
+- Create: `performance/scenarios/.gitkeep` (placeholder, removed when real files added)
+
+- [ ] **Step 1: Create worktree for this branch**
+
+```bash
+git worktree add ../todo-app-perf feature/performance-framework
+cd ../todo-app-perf
+```
+
+If branch doesn't exist yet:
+```bash
+git worktree add -b feature/performance-framework ../todo-app-perf main
+cd ../todo-app-perf
+```
+
+- [ ] **Step 2: Create the directory structure**
+
+```bash
+mkdir -p performance/lib performance/scenarios performance/reports
+```
+
+- [ ] **Step 3: Create `.gitignore` for reports**
+
+Create `performance/.gitignore`:
+```
+reports/*.json
+reports/*.html
+reports/*.csv
+```
+
+- [ ] **Step 4: Create `.gitkeep` for reports dir**
+
+```bash
+touch performance/reports/.gitkeep
+```
+
+- [ ] **Step 5: Commit scaffold**
+
+```bash
+git add performance/
+git commit -m "feat: scaffold performance testing directory structure"
+```
+
+---
+
+## Task 2: `lib/auth.js` — per-VU authentication
+
+**Files:**
+- Create: `performance/lib/auth.js`
+
+**Behavior:**
+- Module-level `let token = null` guard — first call to `getToken()` performs register + login, subsequent calls return cached token
+- `POST /auth/register` — JSON body, handles 409 by skipping to login
+- `POST /auth/login` — form-encoded body (`application/x-www-form-urlencoded`)
+- Username pattern: `user_perf_${__VU}` — unique per VU, stable across iterations
+
+- [ ] **Step 1: Create `performance/lib/auth.js`**
+
+```javascript
+import http from 'k6/http';
+import { check } from 'k6';
+
+// Module-level token cache — one per VU (each VU has its own module scope)
+let token = null;
+
+const PASSWORD = 'PerfTest123!';
+
+export function getToken(baseUrl) {
+  if (token !== null) {
+    return token;
+  }
+
+  const username = `user_perf_${__VU}`;
+
+  // Register — 409 means user already exists from a prior run, that's fine
+  const registerRes = http.post(
+    `${baseUrl}/auth/register`,
+    JSON.stringify({ username, password: PASSWORD }),
+    { headers: { 'Content-Type': 'application/json' } }
+  );
+  check(registerRes, {
+    'register: 201 or 409': (r) => r.status === 201 || r.status === 409,
+  });
+
+  // Login — always required (even after 409 on register)
+  // NOTE: /auth/login requires application/x-www-form-urlencoded (FastAPI OAuth2PasswordRequestForm)
+  const loginRes = http.post(
+    `${baseUrl}/auth/login`,
+    `username=${encodeURIComponent(username)}&password=${encodeURIComponent(PASSWORD)}`,
+    { headers: { 'Content-Type': 'application/x-www-form-urlencoded' } }
+  );
+  check(loginRes, {
+    'login: status 200': (r) => r.status === 200,
+    'login: has access_token': (r) => r.json('access_token') !== undefined,
+  });
+
+  token = loginRes.json('access_token');
+  return token;
+}
+```
+
+- [ ] **Step 2: Verify the file looks correct (dry read)**
+
+```bash
+cat performance/lib/auth.js
+```
+
+Expected: file content matches above, no syntax errors visible.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add performance/lib/auth.js
+git commit -m "feat: add lib/auth.js with per-VU register/login and 409 handling"
+```
+
+---
+
+## Task 3: `lib/client.js` — HTTP wrapper
+
+**Files:**
+- Create: `performance/lib/client.js`
+
+**Behavior:**
+- Returns a `client` object with `get`, `post`, `put`, `delete` methods
+- Pre-sets `Authorization: Bearer <token>` and `Content-Type: application/json` on all requests
+- All methods return the raw k6 response for the caller to check
+
+- [ ] **Step 1: Create `performance/lib/client.js`**
+
+```javascript
+import http from 'k6/http';
+
+export function makeClient(baseUrl, token) {
+  const headers = {
+    'Authorization': `Bearer ${token}`,
+    'Content-Type': 'application/json',
+  };
+
+  return {
+    get: (path) =>
+      http.get(`${baseUrl}${path}`, { headers }),
+
+    post: (path, body) =>
+      http.post(`${baseUrl}${path}`, JSON.stringify(body), { headers }),
+
+    put: (path, body) =>
+      http.put(`${baseUrl}${path}`, JSON.stringify(body), { headers }),
+
+    del: (path) =>
+      http.del(`${baseUrl}${path}`, null, { headers }),
+  };
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add performance/lib/client.js
+git commit -m "feat: add lib/client.js HTTP wrapper with auth header"
+```
+
+---
+
+## Task 4: `lib/data.js` — payload generators
+
+**Files:**
+- Create: `performance/lib/data.js`
+
+**Behavior:**
+- `todoPayload(vuId, iter)` — returns a unique todo create payload using VU ID + iteration counter
+- Titles are unique across VUs and iterations to prevent DB unique constraint issues
+
+- [ ] **Step 1: Create `performance/lib/data.js`**
+
+```javascript
+export function todoPayload() {
+  // __VU and __ITER are k6 built-ins: VU ID (1-indexed) and iteration (0-indexed)
+  return {
+    title: `perf-todo-vu${__VU}-iter${__ITER}`,
+    type: 'todo',
+  };
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add performance/lib/data.js
+git commit -m "feat: add lib/data.js deterministic todo payload generator"
+```
+
+---
+
+## Task 5: `scenarios/smoke.js` — smoke test (CI scenario)
+
+**Files:**
+- Create: `performance/scenarios/smoke.js`
+
+**Behavior:**
+- 1 VU, 30 seconds
+- Per-iteration: auth guard → GET /todos → POST /todos → PUT /todos/{id} → DELETE /todos/{id}
+- Checks on every response (status code + body shape)
+- Thresholds: CI strict (`p(95)<500`, `rate<0.01`, `rate>0.99`) vs local relaxed via `__ENV.CI`
+- Uses `handleSummary` to write HTML report
+
+- [ ] **Step 1: Create `performance/scenarios/smoke.js`**
+
+```javascript
+import { check } from 'k6';
+import { htmlReport } from 'https://raw.githubusercontent.com/grafana/k6-reporter/main/dist/bundle.js';
+import { textSummary } from 'https://jslib.k6.io/k6-summary/0.0.1/index.js';
+import { getToken } from '../lib/auth.js';
+import { makeClient } from '../lib/client.js';
+import { todoPayload } from '../lib/data.js';
+
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:8000';
+const IS_CI = !!__ENV.CI;
+
+export const options = {
+  vus: 1,
+  duration: '30s',
+  thresholds: {
+    http_req_duration: [IS_CI ? 'p(95)<500' : 'p(95)<1000'],
+    http_req_failed:   [IS_CI ? 'rate<0.01' : 'rate<0.05'],
+    checks:            [IS_CI ? 'rate>0.99' : 'rate>0.95'],
+  },
+};
+
+export default function () {
+  const token = getToken(BASE_URL);
+  const client = makeClient(BASE_URL, token);
+
+  // GET /todos
+  const listRes = client.get('/todos');
+  check(listRes, {
+    'GET /todos: status 200': (r) => r.status === 200,
+    'GET /todos: returns array': (r) => Array.isArray(r.json()),
+  });
+
+  // POST /todos
+  const payload = todoPayload();
+  const createRes = client.post('/todos', payload);
+  check(createRes, {
+    'POST /todos: status 201': (r) => r.status === 201,
+    'POST /todos: has id': (r) => r.json('id') !== undefined,
+    'POST /todos: title matches': (r) => r.json('title') === payload.title,
+    'POST /todos: completed is false': (r) => r.json('completed') === false,
+  });
+
+  const todoId = createRes.json('id');
+
+  // PUT /todos/{id}
+  const updateRes = client.put(`/todos/${todoId}`, { title: `${payload.title}-updated`, completed: true });
+  check(updateRes, {
+    'PUT /todos/{id}: status 200': (r) => r.status === 200,
+    'PUT /todos/{id}: completed is true': (r) => r.json('completed') === true,
+  });
+
+  // DELETE /todos/{id}
+  const deleteRes = client.del(`/todos/${todoId}`);
+  check(deleteRes, {
+    'DELETE /todos/{id}: status 204': (r) => r.status === 204,
+  });
+}
+
+export function handleSummary(data) {
+  return {
+    'reports/smoke-summary.html': htmlReport(data),
+    stdout: textSummary(data, { indent: ' ', enableColors: true }),
+  };
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add performance/scenarios/smoke.js
+git commit -m "feat: add smoke scenario with checks and CI/local thresholds"
+```
+
+---
+
+## Task 6: `docker-compose.perf.yml` — dedicated perf stack
+
+**Files:**
+- Create: `performance/docker-compose.perf.yml`
+
+**Key points:**
+- `postgres_perf`: isolated DB, healthcheck, port not exposed
+- `backend_perf`: same image as dev, `ACCESS_TOKEN_EXPIRE_MINUTES=120` to support soak test
+- `k6`: pinned to `grafana/k6:0.54.0`, mounts `./performance` as `/scripts` and `./performance/reports` as `/reports`
+- `k6` default command runs smoke; overridden by `run.sh` and CI
+
+- [ ] **Step 1: Create `performance/docker-compose.perf.yml`**
+
+```yaml
+services:
+  postgres_perf:
+    image: postgres:13
+    environment:
+      - POSTGRES_USER=user
+      - POSTGRES_PASSWORD=password
+      - POSTGRES_DB=tododb_perf
+    volumes:
+      - postgres_perf_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U user -d tododb_perf"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+  backend_perf:
+    build:
+      context: ../backend
+    ports:
+      - "8001:8000"
+    volumes:
+      - ../backend:/app
+    environment:
+      - PYTHONUNBUFFERED=1
+      - PYTHONPATH=/app
+      - DATABASE_URL=postgresql+asyncpg://user:password@postgres_perf/tododb_perf
+      - SECRET_KEY=perf-test-secret-key-not-for-production
+      - ACCESS_TOKEN_EXPIRE_MINUTES=120
+    depends_on:
+      postgres_perf:
+        condition: service_healthy
+    restart: unless-stopped
+
+  k6:
+    image: grafana/k6:0.54.0
+    volumes:
+      - ./:/scripts
+      - ./reports:/reports
+    environment:
+      - BASE_URL=http://backend_perf:8000
+    command: run /scripts/scenarios/smoke.js --out json=/reports/result.json
+    depends_on:
+      - backend_perf
+    networks:
+      - default
+
+volumes:
+  postgres_perf_data:
+```
+
+> Note: `build: context: ../backend` because this file lives inside `performance/`, not the repo root.
+
+- [ ] **Step 2: Verify the backend port does not conflict with dev stack**
+
+```bash
+# Dev stack uses port 8000; perf stack uses 8001 to allow both running simultaneously
+grep "ports" performance/docker-compose.perf.yml
+```
+
+Expected: `- "8001:8000"`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add performance/docker-compose.perf.yml
+git commit -m "feat: add docker-compose.perf.yml with isolated postgres_perf stack"
+```
+
+---
+
+## Task 7: `run.sh` — local runner
+
+**Files:**
+- Create: `performance/run.sh`
+
+**Behavior:**
+- Usage: `./run.sh <scenario> [BASE_URL]`
+- If BASE_URL provided, runs k6 directly against that URL (no Docker Compose)
+- If no BASE_URL, starts Docker Compose perf stack and runs k6 inside it
+- Propagates k6 exit code without modification
+
+- [ ] **Step 1: Create `performance/run.sh`**
+
+```bash
+#!/usr/bin/env bash
+set -e
+
+SCENARIO=${1:-smoke}
+BASE_URL=${2:-""}
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [ -z "$BASE_URL" ]; then
+  # Run against local Docker Compose perf stack
+  echo "Starting perf stack and running scenario: $SCENARIO"
+  docker compose -f "$SCRIPT_DIR/docker-compose.perf.yml" up -d postgres_perf backend_perf
+  docker compose -f "$SCRIPT_DIR/docker-compose.perf.yml" run --rm \
+    -e BASE_URL=http://backend_perf:8000 \
+    k6 run "/scripts/scenarios/${SCENARIO}.js" --out "json=/reports/${SCENARIO}-result.json"
+  EXIT_CODE=$?
+  docker compose -f "$SCRIPT_DIR/docker-compose.perf.yml" stop backend_perf
+  exit $EXIT_CODE
+else
+  # Run k6 directly against provided BASE_URL (staging, prod, etc.)
+  echo "Running scenario: $SCENARIO against $BASE_URL"
+  docker run --rm \
+    -v "$SCRIPT_DIR:/scripts" \
+    -v "$SCRIPT_DIR/reports:/reports" \
+    -e "BASE_URL=$BASE_URL" \
+    grafana/k6:0.54.0 run "/scripts/scenarios/${SCENARIO}.js" --out "json=/reports/${SCENARIO}-result.json"
+fi
+```
+
+- [ ] **Step 2: Make executable**
+
+```bash
+chmod +x performance/run.sh
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add performance/run.sh
+git commit -m "feat: add run.sh local runner with Docker Compose and remote target support"
+```
+
+---
+
+## Task 8: Remaining scenarios — load, stress, soak, spike
+
+**Files:**
+- Create: `performance/scenarios/load.js`
+- Create: `performance/scenarios/stress.js`
+- Create: `performance/scenarios/soak.js`
+- Create: `performance/scenarios/spike.js`
+
+All four share the same `default()` function as smoke. Only `options` differs.
+
+- [ ] **Step 1: Create `performance/scenarios/load.js`**
+
+```javascript
+import { check } from 'k6';
+import { getToken } from '../lib/auth.js';
+import { makeClient } from '../lib/client.js';
+import { todoPayload } from '../lib/data.js';
+
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:8000';
+const IS_CI = !!__ENV.CI;
+
+export const options = {
+  stages: [
+    { duration: '1m', target: 50 },
+    { duration: '3m', target: 50 },
+    { duration: '1m', target: 0 },
+  ],
+  thresholds: {
+    http_req_duration: [IS_CI ? 'p(95)<500' : 'p(95)<1000'],
+    http_req_failed:   [IS_CI ? 'rate<0.01' : 'rate<0.05'],
+    checks:            [IS_CI ? 'rate>0.99' : 'rate>0.95'],
+  },
+};
+
+export default function () {
+  const token = getToken(BASE_URL);
+  const client = makeClient(BASE_URL, token);
+  const payload = todoPayload();
+
+  const listRes = client.get('/todos');
+  check(listRes, { 'GET /todos: 200': (r) => r.status === 200 });
+
+  const createRes = client.post('/todos', payload);
+  check(createRes, {
+    'POST /todos: 201': (r) => r.status === 201,
+    'POST /todos: has id': (r) => r.json('id') !== undefined,
+  });
+
+  const todoId = createRes.json('id');
+
+  const updateRes = client.put(`/todos/${todoId}`, { completed: true });
+  check(updateRes, { 'PUT /todos/{id}: 200': (r) => r.status === 200 });
+
+  const deleteRes = client.del(`/todos/${todoId}`);
+  check(deleteRes, { 'DELETE /todos/{id}: 204': (r) => r.status === 204 });
+}
+```
+
+- [ ] **Step 2: Create `performance/scenarios/stress.js`**
+
+```javascript
+import { check } from 'k6';
+import { getToken } from '../lib/auth.js';
+import { makeClient } from '../lib/client.js';
+import { todoPayload } from '../lib/data.js';
+
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:8000';
+const IS_CI = !!__ENV.CI;
+
+export const options = {
+  stages: [
+    { duration: '2m', target: 50 },
+    { duration: '3m', target: 100 },
+    { duration: '3m', target: 200 },
+    { duration: '2m', target: 0 },
+  ],
+  thresholds: {
+    http_req_duration: [IS_CI ? 'p(95)<500' : 'p(95)<2000'],
+    http_req_failed:   ['rate<0.10'],
+    checks:            ['rate>0.90'],
+  },
+};
+
+export default function () {
+  const token = getToken(BASE_URL);
+  const client = makeClient(BASE_URL, token);
+  const payload = todoPayload();
+
+  const listRes = client.get('/todos');
+  check(listRes, { 'GET /todos: 200': (r) => r.status === 200 });
+
+  const createRes = client.post('/todos', payload);
+  check(createRes, {
+    'POST /todos: 201': (r) => r.status === 201,
+    'POST /todos: has id': (r) => r.json('id') !== undefined,
+  });
+
+  if (createRes.status === 201) {
+    const todoId = createRes.json('id');
+    const updateRes = client.put(`/todos/${todoId}`, { completed: true });
+    check(updateRes, { 'PUT /todos/{id}: 200': (r) => r.status === 200 });
+    const deleteRes = client.del(`/todos/${todoId}`);
+    check(deleteRes, { 'DELETE /todos/{id}: 204': (r) => r.status === 204 });
+  }
+}
+```
+
+- [ ] **Step 3: Create `performance/scenarios/soak.js`**
+
+```javascript
+import { check } from 'k6';
+import { getToken } from '../lib/auth.js';
+import { makeClient } from '../lib/client.js';
+import { todoPayload } from '../lib/data.js';
+
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:8000';
+
+// NOTE: Requires ACCESS_TOKEN_EXPIRE_MINUTES >= 120 in the target environment.
+// docker-compose.perf.yml sets this to 120. For external targets, verify before running.
+export const options = {
+  vus: 20,
+  duration: '30m',
+  thresholds: {
+    http_req_duration: ['p(95)<1000'],
+    http_req_failed:   ['rate<0.01'],
+    checks:            ['rate>0.99'],
+  },
+};
+
+export default function () {
+  const token = getToken(BASE_URL);
+  const client = makeClient(BASE_URL, token);
+  const payload = todoPayload();
+
+  const listRes = client.get('/todos');
+  check(listRes, { 'GET /todos: 200': (r) => r.status === 200 });
+
+  const createRes = client.post('/todos', payload);
+  check(createRes, {
+    'POST /todos: 201': (r) => r.status === 201,
+    'POST /todos: has id': (r) => r.json('id') !== undefined,
+  });
+
+  if (createRes.status === 201) {
+    const todoId = createRes.json('id');
+    const deleteRes = client.del(`/todos/${todoId}`);
+    check(deleteRes, { 'DELETE /todos/{id}: 204': (r) => r.status === 204 });
+  }
+}
+```
+
+- [ ] **Step 4: Create `performance/scenarios/spike.js`**
+
+```javascript
+import { check } from 'k6';
+import { getToken } from '../lib/auth.js';
+import { makeClient } from '../lib/client.js';
+import { todoPayload } from '../lib/data.js';
+
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:8000';
+
+// WARNING: This scenario targets 500 VUs. Do NOT run on a developer laptop.
+// Use a server or CI environment with at least 8GB RAM and 4 CPUs.
+export const options = {
+  stages: [
+    { duration: '10s', target: 0 },
+    { duration: '20s', target: 500 },
+    { duration: '1m', target: 500 },
+    { duration: '30s', target: 0 },
+  ],
+  thresholds: {
+    http_req_failed: ['rate<0.20'],
+    checks:          ['rate>0.80'],
+  },
+};
+
+export default function () {
+  const token = getToken(BASE_URL);
+  const client = makeClient(BASE_URL, token);
+  const payload = todoPayload();
+
+  const listRes = client.get('/todos');
+  check(listRes, { 'GET /todos: 200 or 503': (r) => r.status === 200 || r.status === 503 });
+
+  const createRes = client.post('/todos', payload);
+  check(createRes, { 'POST /todos: 201 or 5xx': (r) => r.status === 201 || r.status >= 500 });
+
+  if (createRes.status === 201) {
+    const todoId = createRes.json('id');
+    client.del(`/todos/${todoId}`);
+  }
+}
+```
+
+- [ ] **Step 5: Commit all scenarios**
+
+```bash
+git add performance/scenarios/
+git commit -m "feat: add load, stress, soak, spike scenarios"
+```
+
+---
+
+## Task 9: GitHub Actions `perf.yml`
+
+**Files:**
+- Create: `.github/workflows/perf.yml`
+
+- [ ] **Step 1: Create `.github/workflows/perf.yml`**
+
+```yaml
+name: Performance Tests
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Start perf stack
+        run: docker compose -f performance/docker-compose.perf.yml up -d postgres_perf backend_perf
+
+      - name: Wait for backend to be ready
+        run: |
+          echo "Waiting for backend_perf..."
+          for i in $(seq 1 30); do
+            if docker compose -f performance/docker-compose.perf.yml exec -T backend_perf curl -sf http://localhost:8000/ > /dev/null 2>&1; then
+              echo "Backend ready"
+              break
+            fi
+            echo "Attempt $i/30..."
+            sleep 2
+          done
+
+      - name: Run smoke test
+        run: |
+          docker compose -f performance/docker-compose.perf.yml run --rm \
+            -e CI=true \
+            -e BASE_URL=http://backend_perf:8000 \
+            k6 run /scripts/scenarios/smoke.js \
+            --out json=/reports/smoke-result.json
+
+      - name: Upload smoke report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: perf-smoke-report-${{ github.run_number }}
+          path: performance/reports/
+          retention-days: 30
+
+      - name: Tear down perf stack
+        if: always()
+        run: docker compose -f performance/docker-compose.perf.yml down
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .github/workflows/perf.yml
+git commit -m "feat: add GitHub Actions smoke test workflow"
+```
+
+---
+
+## Task 10: README
+
+**Files:**
+- Create: `performance/README.md`
+
+- [ ] **Step 1: Create `performance/README.md`**
+
+```markdown
+# Performance Testing
+
+k6-based performance testing framework for the Todo API.
+
+## Quick Start
+
+```bash
+# Run smoke test against local Docker perf stack
+./performance/run.sh smoke
+
+# Run load test against local Docker perf stack
+./performance/run.sh load
+
+# Run against a deployed environment
+./performance/run.sh smoke https://staging.example.com
+./performance/run.sh load https://staging.example.com
+```
+
+## Scenarios
+
+| Scenario | VUs | Duration | Purpose |
+|----------|-----|----------|---------|
+| `smoke`  | 1   | 30s      | Sanity check — runs in CI on every PR |
+| `load`   | 1→50→0 | 5min | Baseline normal traffic |
+| `stress` | 1→200→0 | 10min | Find degradation point |
+| `soak`   | 20 steady | 30min | Memory leaks, connection exhaustion |
+| `spike`  | 0→500→0 | 2min | Resilience under sudden burst |
+
+## ⚠️ Resource Warnings
+
+**`stress` and `spike` scenarios require significant resources.**
+Do NOT run them on a developer laptop. Use a server or CI environment with at least 8GB RAM and 4 CPUs.
+
+**`soak` requires `ACCESS_TOKEN_EXPIRE_MINUTES >= 120`** in the target environment.
+The local perf stack (`docker-compose.perf.yml`) sets this automatically. For external targets, verify before running.
+
+## Local Stack Management
+
+```bash
+# Start perf stack manually (leaves it running for multiple test runs)
+docker compose -f performance/docker-compose.perf.yml up -d postgres_perf backend_perf
+
+# Tear down and remove volumes (cleans up test users/data)
+docker compose -f performance/docker-compose.perf.yml down -v
+```
+
+Pruning the volume resets the database. On the next run, test users (`user_perf_*`) will be re-created fresh.
+If you don't prune, repeated runs reuse existing test users (the auth library handles 409 automatically).
+
+## Reports
+
+Reports are written to `performance/reports/` (gitignored).
+- `*.json` — raw k6 metrics (machine-readable)
+- `*.html` — human-readable summary (smoke scenario only)
+
+## CI
+
+The smoke test runs automatically on every PR to `main` and on push to `main`.
+A threshold breach fails the build. Artifacts are retained for 30 days.
+
+## Threshold Reference
+
+| Metric | CI (strict) | Local (relaxed) |
+|--------|------------|-----------------|
+| `http_req_duration p(95)` | < 500ms | < 1000ms |
+| `http_req_failed rate` | < 1% | < 5% |
+| `checks pass rate` | > 99% | > 95% |
+
+Set `CI=true` env var to use strict thresholds: `./run.sh smoke --env CI=true`
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add performance/README.md
+git commit -m "docs: add performance testing README with usage, warnings, and CI reference"
+```
+
+---
+
+## Task 11: End-to-end smoke run verification
+
+Verify everything works together before declaring done.
+
+- [ ] **Step 1: Start the perf stack**
+
+```bash
+docker compose -f performance/docker-compose.perf.yml up -d postgres_perf backend_perf
+```
+
+Expected: both containers start, backend_perf reaches healthy state.
+
+- [ ] **Step 2: Run smoke test locally**
+
+```bash
+./performance/run.sh smoke
+```
+
+Expected output includes:
+- `register: 201 or 409 ✓`
+- `login: status 200 ✓`
+- `GET /todos: status 200 ✓`
+- `POST /todos: status 201 ✓`
+- `PUT /todos/{id}: status 200 ✓`
+- `DELETE /todos/{id}: status 204 ✓`
+- All thresholds: `✓`
+- Exit code 0
+
+- [ ] **Step 3: Verify report file created**
+
+```bash
+ls performance/reports/
+```
+
+Expected: `smoke-result.json` exists.
+
+- [ ] **Step 4: Tear down**
+
+```bash
+docker compose -f performance/docker-compose.perf.yml down
+```
+
+- [ ] **Step 5: Final commit if any fixups were needed**
+
+```bash
+git add -p  # stage only actual fixes
+git commit -m "fix: smoke run verification fixups"
+```
+
+- [ ] **Step 6: Push branch**
+
+```bash
+git push -u origin feature/performance-framework
+```

--- a/docs/superpowers/specs/2026-03-23-e2e-framework-design.md
+++ b/docs/superpowers/specs/2026-03-23-e2e-framework-design.md
@@ -1,0 +1,272 @@
+# E2E Testing Framework Design
+
+**Date:** 2026-03-23
+**Project:** todo-app
+**Status:** Approved
+
+---
+
+## Overview
+
+Add an end-to-end testing framework to the existing todo-app monorepo using Playwright with TypeScript. Tests live in a top-level `/e2e` directory, run against a dedicated isolated Docker Compose stack, and execute both locally and in CI.
+
+---
+
+## Technology Choices
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Tool | Playwright (TypeScript) | First-class TS support, `@playwright/test` runner, strong CI integration, largest e2e community |
+| Language | TypeScript | Consistent with frontend, can share types, native browser ecosystem |
+| Location | `/e2e` in existing repo | App and tests change together; prevents drift; simpler CI wiring |
+| Structure | Page Object Model | Maintainable at scale; selectors in one place; tests read as user stories |
+| App environment | `docker-compose.e2e.yml` | Isolated PostgreSQL; reproducible in CI; dev environment untouched |
+
+---
+
+## Directory Structure
+
+```
+todo-app/
+├── backend/
+├── frontend/
+├── e2e/
+│   ├── pages/
+│   │   ├── AuthPage.ts           ← login/register form interactions
+│   │   └── TodoPage.ts           ← todo list, form, timeline tab
+│   ├── fixtures/
+│   │   ├── auth.fixture.ts       ← storageState: saves logged-in session once, reuses across tests
+│   │   └── api.fixture.ts        ← direct HTTP calls for data seeding and cleanup
+│   ├── tests/
+│   │   ├── auth.spec.ts          ← register, login, logout, 401 redirect
+│   │   ├── todos.spec.ts         ← add, complete, delete, user isolation
+│   │   └── timeline.spec.ts      ← timeline tab, feature flag on/off
+│   ├── playwright.config.ts
+│   └── package.json
+├── docker-compose.yml            ← existing dev stack (unchanged)
+└── docker-compose.e2e.yml        ← new: isolated test stack
+```
+
+---
+
+## Configuration
+
+### `playwright.config.ts`
+
+- `baseURL`: `http://localhost:3000`
+- `storageState`: `e2e/.auth/user.json` — loaded by tests that require authentication
+- Browser projects: `chromium` always; `firefox` in CI only
+- `globalSetup`: waits for backend and frontend health checks before any test runs
+- `testDir`: `./e2e/tests` — isolated from `frontend/src` so `react-scripts test` never picks up e2e specs
+- `retries`: 1 in CI, 0 locally
+
+### `docker-compose.e2e.yml`
+
+Mirrors `docker-compose.yml` with:
+- Separate named volume `postgres_e2e_data` — never shares state with dev DB
+- Backend `DATABASE_URL` points at the e2e database
+- Frontend served with `REACT_APP_TIMELINE_FEATURE_FLAG=true`
+- All services on the same ports (`3000`, `8000`) so `playwright.config.ts` needs no environment-specific config
+
+---
+
+## Page Objects
+
+### `AuthPage.ts`
+
+Wraps the login/register UI. Selectors based on existing `AuthForm.tsx` — no `data-testid` required:
+
+```ts
+class AuthPage {
+  async login(username: string, password: string) {
+    await this.page.getByPlaceholder('Username').fill(username);
+    await this.page.getByPlaceholder('Password').fill(password);
+    await this.page.getByRole('button', { name: 'Log In' }).click();
+  }
+
+  async register(username: string, password: string) {
+    await this.page.getByRole('button', { name: 'Switch to Register' }).click();
+    await this.page.getByPlaceholder('Username').fill(username);
+    await this.page.getByPlaceholder('Password').fill(password);
+    await this.page.getByRole('button', { name: 'Register' }).click();
+  }
+
+  async expectError(message: string) {
+    await expect(this.page.locator('.auth-error')).toHaveText(message);
+  }
+}
+```
+
+### `TodoPage.ts`
+
+Wraps the main app. Key pattern: scope to `.todo-item` container filtered by text to disambiguate repeated Delete buttons — no `data-testid` required:
+
+```ts
+class TodoPage {
+  async addTodo(text: string, type: 'todo' | 'timeline' = 'todo') {
+    await this.page.getByPlaceholder('Add a new task...').fill(text);
+    if (type === 'timeline') {
+      await this.page.getByRole('combobox').selectOption('timeline');
+    }
+    await this.page.getByRole('button', { name: 'Add' }).click();
+  }
+
+  private todoRow(text: string) {
+    return this.page.locator('.todo-item').filter({ hasText: text });
+  }
+
+  async toggleTodo(text: string) {
+    await this.todoRow(text).getByRole('checkbox').click();
+  }
+
+  async deleteTodo(text: string) {
+    await this.todoRow(text).getByRole('button', { name: 'Delete' }).click();
+  }
+
+  async expectCompleted(text: string) {
+    await expect(
+      this.todoRow(text).locator('div').first()
+    ).toHaveCSS('text-decoration', /line-through/);
+  }
+
+  async switchToTimeline() {
+    await this.page.getByRole('tab', { name: 'Timeline' }).click();
+  }
+
+  async logout() {
+    await this.page.getByRole('button', { name: 'Logout' }).click();
+  }
+}
+```
+
+---
+
+## Selector Strategy
+
+Selectors use a priority tier — no blanket requirement for `data-testid`:
+
+| Tier | Strategy | When to use |
+|---|---|---|
+| 1 | `getByRole`, `getByLabel`, `getByPlaceholder` | Standard HTML elements — most cases |
+| 2 | `getByText` | Stable visible text |
+| 3 | `.locator('.css-class').filter({ hasText })` | Repeated components (todo rows) |
+| 4 | `locator('css-selector')` | No semantic hook available |
+| 5 | `data-testid` | Genuinely ambiguous elements only — negotiated selectively |
+
+CSS classes already in the codebase (`auth-error`, `auth-switch-btn`, `todo-item`, `task-text`, `delete-btn`, `logout-btn`) are used as fallbacks where semantic locators are insufficient.
+
+**Edge case:** two todos with identical text. Handled by using unique text in test data (e.g. generated suffixes), not by requiring `data-testid`.
+
+---
+
+## Fixtures
+
+### `auth.fixture.ts` — Session reuse
+
+`globalSetup` calls `POST /auth/login` directly (no UI), saves the token to `e2e/.auth/user.json`. Tests that need auth load `storageState: 'e2e/.auth/user.json'` — browser starts already authenticated. No login traversal on every test.
+
+### `api.fixture.ts` — Data seeding
+
+Direct HTTP calls to the backend API for test setup and teardown:
+
+```ts
+class ApiFixture {
+  async createTodo(token: string, title: string, type = 'todo'): Promise<Todo>
+  async clearTodos(token: string): Promise<void>
+  async registerUser(username: string, password: string): Promise<string> // returns token
+}
+```
+
+Tests that verify delete/complete start with API-seeded data, not UI-created data. This isolates the interaction under test.
+
+---
+
+## Test Scenarios
+
+### `auth.spec.ts`
+- Register a new user → lands on todo list
+- Login with valid credentials → lands on todo list
+- Login with wrong password → shows error message
+- Logout → returns to login screen
+- Accessing app after token expiry → redirected to login (401 handling)
+
+### `todos.spec.ts`
+- Add a todo → appears in list
+- Complete a todo → checkbox checked, text struck through
+- Delete a todo → removed from list
+- Add multiple todos → all appear; delete one → others remain
+- User A's todos not visible to User B (isolation)
+
+### `timeline.spec.ts`
+- Add a timeline item → appears in Timeline tab (not in To-Do tab)
+- Timeline tab visible when feature flag is `true`
+- Timeline tab hidden when feature flag is `false`
+
+---
+
+## CI Integration
+
+### GitHub Actions workflow (`.github/workflows/e2e.yml`)
+
+```yaml
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: '20' }
+      - run: npm ci
+        working-directory: e2e
+      - run: npx playwright install --with-deps chromium
+        working-directory: e2e
+      - run: docker compose -f docker-compose.e2e.yml up -d
+      - run: npx playwright test
+        working-directory: e2e
+      - run: docker compose -f docker-compose.e2e.yml down -v
+        if: always()
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: playwright-report
+          path: e2e/playwright-report/
+```
+
+**Two test subsets:**
+- `--grep @smoke` — fast subset (auth + basic todo CRUD) on every PR
+- Full suite — on push to `main` and nightly scheduled run
+
+---
+
+## Running Locally
+
+```bash
+# start isolated stack
+docker compose -f docker-compose.e2e.yml up -d
+
+# install and run all tests
+cd e2e && npm ci && npx playwright test
+
+# run smoke tests only
+npx playwright test --grep @smoke
+
+# headed mode for debugging
+npx playwright test --headed
+
+# teardown
+docker compose -f docker-compose.e2e.yml down -v
+```
+
+---
+
+## Out of Scope
+
+- Visual regression testing (screenshot diffing)
+- Performance/load testing
+- Mobile viewport testing
+- API-only tests (covered by existing pytest suite in `backend/tests/`)

--- a/docs/superpowers/specs/2026-03-23-e2e-framework-design.md
+++ b/docs/superpowers/specs/2026-03-23-e2e-framework-design.md
@@ -21,6 +21,7 @@ Add an end-to-end testing framework to the existing todo-app monorepo using Play
 | Location | `/e2e` in existing repo | App and tests change together; prevents drift; simpler CI wiring |
 | Structure | Page Object Model | Maintainable at scale; selectors in one place; tests read as user stories |
 | App environment | `docker-compose.e2e.yml` | Isolated PostgreSQL; reproducible in CI; dev environment untouched |
+| Minimum Playwright version | 1.30+ | Required for regex support in `toHaveCSS` assertions |
 
 ---
 
@@ -35,12 +36,13 @@ todo-app/
 │   │   ├── AuthPage.ts           ← login/register form interactions
 │   │   └── TodoPage.ts           ← todo list, form, timeline tab
 │   ├── fixtures/
-│   │   ├── auth.fixture.ts       ← storageState: saves logged-in session once, reuses across tests
+│   │   ├── auth.fixture.ts       ← test fixture that loads saved storageState per-test
 │   │   └── api.fixture.ts        ← direct HTTP calls for data seeding and cleanup
 │   ├── tests/
 │   │   ├── auth.spec.ts          ← register, login, logout, 401 redirect
 │   │   ├── todos.spec.ts         ← add, complete, delete, user isolation
-│   │   └── timeline.spec.ts      ← timeline tab, feature flag on/off
+│   │   └── timeline.spec.ts      ← timeline tab visible with feature flag on
+│   ├── global-setup.ts           ← runs once before suite: health checks + saves storageState
 │   ├── playwright.config.ts
 │   └── package.json
 ├── docker-compose.yml            ← existing dev stack (unchanged)
@@ -54,11 +56,67 @@ todo-app/
 ### `playwright.config.ts`
 
 - `baseURL`: `http://localhost:3000`
-- `storageState`: `e2e/.auth/user.json` — loaded by tests that require authentication
-- Browser projects: `chromium` always; `firefox` in CI only
-- `globalSetup`: waits for backend and frontend health checks before any test runs
-- `testDir`: `./e2e/tests` — isolated from `frontend/src` so `react-scripts test` never picks up e2e specs
+- `storageState`: loaded per-test via `auth.fixture.ts` (path: `path.join(__dirname, '.auth/user.json')`)
+- Browser projects: `chromium` always (locally and CI); `firefox` excluded — one-browser CI is standard for a project this size and avoids the complexity of maintaining two browser installs
+- `globalSetup`: `'./global-setup.ts'` — polls health endpoints before any test runs
+- `testDir`: `'./tests'` — isolated from `frontend/src` so `react-scripts test` never picks up e2e specs
 - `retries`: 1 in CI, 0 locally
+
+### `global-setup.ts`
+
+Runs once before the entire suite. Two responsibilities:
+
+1. **Health check**: polls `GET http://localhost:8000/` (backend) and `GET http://localhost:3000` (frontend) every 2 seconds, up to 60 seconds total. Throws a descriptive error if either service does not respond in time.
+2. **Auth state**: calls `POST http://localhost:8000/auth/register` then `POST http://localhost:8000/auth/login` to create a known test user, then uses Playwright's `chromium.launch()` to save `storageState` to `e2e/.auth/user.json`. This file is loaded per-test by `auth.fixture.ts`.
+
+**Important — login encoding:** The backend's `/auth/login` endpoint uses FastAPI's `OAuth2PasswordRequestForm`, which requires `Content-Type: application/x-www-form-urlencoded`, not JSON. Both `global-setup.ts` and `api.fixture.ts` must send login requests using `URLSearchParams`:
+
+```ts
+fetch('http://localhost:8000/auth/login', {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+  body: new URLSearchParams({ username, password }),
+})
+```
+
+Sending a JSON body to this endpoint returns `422 Unprocessable Entity`.
+
+The saved test user credentials (e.g. `e2e-user` / `e2e-password`) are defined as constants in `global-setup.ts` and exported so `api.fixture.ts` can reuse them to obtain a token for API seeding.
+
+### `auth.fixture.ts`
+
+A `test.extend`-based Playwright fixture (not `globalSetup`). Provides an `authenticatedPage` fixture that loads `storageState` from `e2e/.auth/user.json` before each test:
+
+```ts
+export const test = base.extend({
+  authenticatedPage: async ({ browser }, use) => {
+    const context = await browser.newContext({
+      storageState: path.join(__dirname, '../.auth/user.json'),
+    });
+    const page = await context.newPage();
+    await use(page);
+    await context.close();
+  },
+});
+```
+
+Tests that require auth import `test` from `auth.fixture.ts`. Tests for the login/register UI import the base `test` from `@playwright/test` directly.
+
+### `api.fixture.ts`
+
+Direct HTTP calls to the backend API using Node's `fetch`. Obtains a token by calling `POST /auth/login` with the same test user credentials exported from `global-setup.ts`. Provides:
+
+```ts
+class ApiFixture {
+  // token is obtained internally via login at fixture construction time
+  async createTodo(title: string, type: 'todo' | 'timeline' = 'todo'): Promise<Todo>
+  async clearTodos(): Promise<void>
+}
+```
+
+`clearTodos` is called in `afterEach` hooks so each test starts with a clean state. There is no bulk-delete endpoint on the backend; `clearTodos` must call `GET /todos` to retrieve all IDs, then call `DELETE /todos/{id}` for each one sequentially.
+
+**Important — login encoding:** Same constraint as `global-setup.ts` — use `URLSearchParams` body for `/auth/login`.
 
 ### `docker-compose.e2e.yml`
 
@@ -66,7 +124,7 @@ Mirrors `docker-compose.yml` with:
 - Separate named volume `postgres_e2e_data` — never shares state with dev DB
 - Backend `DATABASE_URL` points at the e2e database
 - Frontend served with `REACT_APP_TIMELINE_FEATURE_FLAG=true`
-- All services on the same ports (`3000`, `8000`) so `playwright.config.ts` needs no environment-specific config
+- All services on the same ports (`3000`, `8000`)
 
 ---
 
@@ -99,12 +157,29 @@ class AuthPage {
 
 ### `TodoPage.ts`
 
-Wraps the main app. Key pattern: scope to `.todo-item` container filtered by text to disambiguate repeated Delete buttons — no `data-testid` required:
+Wraps the main app. Key pattern: scope to the `.todo-item` container filtered by text to disambiguate repeated Delete buttons.
+
+**DOM structure note:** `TodoItem.tsx` renders:
+```html
+<div>                                       ← outer wrapper, no class
+  <div class="todo-item task-content">      ← two classes on same element
+    <div style="text-decoration: ...">      ← styled div (line-through when completed)
+      <input type="checkbox" />
+      <span class="task-text">title</span>
+    </div>
+    <button class="delete-btn delete">Delete</button>
+  </div>
+</div>
+```
+
+`todoRow` anchors to `.todo-item` (the inner div with classes). The Delete button and checkbox are both children of this element, so scoping works correctly. The `expectCompleted` assertion targets `.todo-item > div:first-child` to reach the styled div directly:
 
 ```ts
 class TodoPage {
   async addTodo(text: string, type: 'todo' | 'timeline' = 'todo') {
     await this.page.getByPlaceholder('Add a new task...').fill(text);
+    // The type select is always rendered regardless of feature flag;
+    // default value is 'todo' so only change it when creating a timeline item
     if (type === 'timeline') {
       await this.page.getByRole('combobox').selectOption('timeline');
     }
@@ -124,8 +199,9 @@ class TodoPage {
   }
 
   async expectCompleted(text: string) {
+    // targets the first child div of .todo-item which carries the inline line-through style
     await expect(
-      this.todoRow(text).locator('div').first()
+      this.todoRow(text).locator('> div:first-child')
     ).toHaveCSS('text-decoration', /line-through/);
   }
 
@@ -138,6 +214,8 @@ class TodoPage {
   }
 }
 ```
+
+**Edge case:** two todos with identical text. Handled by using unique text in test data (e.g. `uuid`-suffixed titles), not by requiring `data-testid`.
 
 ---
 
@@ -154,30 +232,6 @@ Selectors use a priority tier — no blanket requirement for `data-testid`:
 | 5 | `data-testid` | Genuinely ambiguous elements only — negotiated selectively |
 
 CSS classes already in the codebase (`auth-error`, `auth-switch-btn`, `todo-item`, `task-text`, `delete-btn`, `logout-btn`) are used as fallbacks where semantic locators are insufficient.
-
-**Edge case:** two todos with identical text. Handled by using unique text in test data (e.g. generated suffixes), not by requiring `data-testid`.
-
----
-
-## Fixtures
-
-### `auth.fixture.ts` — Session reuse
-
-`globalSetup` calls `POST /auth/login` directly (no UI), saves the token to `e2e/.auth/user.json`. Tests that need auth load `storageState: 'e2e/.auth/user.json'` — browser starts already authenticated. No login traversal on every test.
-
-### `api.fixture.ts` — Data seeding
-
-Direct HTTP calls to the backend API for test setup and teardown:
-
-```ts
-class ApiFixture {
-  async createTodo(token: string, title: string, type = 'todo'): Promise<Todo>
-  async clearTodos(token: string): Promise<void>
-  async registerUser(username: string, password: string): Promise<string> // returns token
-}
-```
-
-Tests that verify delete/complete start with API-seeded data, not UI-created data. This isolates the interaction under test.
 
 ---
 
@@ -198,9 +252,12 @@ Tests that verify delete/complete start with API-seeded data, not UI-created dat
 - User A's todos not visible to User B (isolation)
 
 ### `timeline.spec.ts`
-- Add a timeline item → appears in Timeline tab (not in To-Do tab)
-- Timeline tab visible when feature flag is `true`
-- Timeline tab hidden when feature flag is `false`
+- Timeline tab is visible when `REACT_APP_TIMELINE_FEATURE_FLAG=true` (the e2e stack always has this set)
+- Add a timeline item via the type select → item appears in Timeline tab, not in To-Do tab
+
+**Prerequisite bug fix:** `App.tsx` currently calls `api.addTodo(text, token)` — it does not pass the `type` argument that `TodoForm` provides. This means the type select in the UI has no effect; items are always created as `type: "todo"`. The "add timeline item" scenario cannot pass until `App.tsx` is updated to forward the `type` argument to `api.addTodo`. This is a pre-existing application bug that must be fixed as part of the e2e implementation work. Similarly, `api.ts`'s `addTodo` does not include `type` in the request body and needs updating.
+
+**Note:** the "flag off" scenario (Timeline tab hidden) is out of scope for this framework. The `docker-compose.e2e.yml` always sets the flag to `true`, matching the dev compose. Testing the flag-off state would require a second compose profile and is deferred.
 
 ---
 
@@ -213,6 +270,8 @@ on:
   pull_request:
   push:
     branches: [main]
+  schedule:
+    - cron: '0 2 * * *'   # nightly at 02:00 UTC
 
 jobs:
   e2e:
@@ -226,7 +285,13 @@ jobs:
       - run: npx playwright install --with-deps chromium
         working-directory: e2e
       - run: docker compose -f docker-compose.e2e.yml up -d
-      - run: npx playwright test
+      - name: Run smoke tests (PRs)
+        if: github.event_name == 'pull_request'
+        run: npx playwright test --grep @smoke
+        working-directory: e2e
+      - name: Run full suite (main / nightly)
+        if: github.event_name != 'pull_request'
+        run: npx playwright test
         working-directory: e2e
       - run: docker compose -f docker-compose.e2e.yml down -v
         if: always()
@@ -237,9 +302,16 @@ jobs:
           path: e2e/playwright-report/
 ```
 
+**Health check:** `global-setup.ts` polls backend and frontend readiness before any test runs (see Configuration section). No explicit `sleep` step required in CI.
+
 **Two test subsets:**
-- `--grep @smoke` — fast subset (auth + basic todo CRUD) on every PR
-- Full suite — on push to `main` and nightly scheduled run
+- PRs: `--grep @smoke` — auth + basic todo CRUD (fast feedback)
+- Push to `main` + nightly: full suite including timeline and user isolation tests
+
+Tests that belong to the smoke subset are tagged `@smoke` in their title:
+```ts
+test('@smoke add a todo and see it in the list', async ...)
+```
 
 ---
 
@@ -269,4 +341,6 @@ docker compose -f docker-compose.e2e.yml down -v
 - Visual regression testing (screenshot diffing)
 - Performance/load testing
 - Mobile viewport testing
-- API-only tests (covered by existing pytest suite in `backend/tests/`)
+- Multi-browser testing (Firefox, Safari) — single-browser (Chromium) CI is standard for this project size
+- Feature flag "off" state testing — deferred; requires a separate compose profile
+- API-only tests — covered by existing pytest suite in `backend/tests/`

--- a/docs/superpowers/specs/2026-03-23-performance-testing-design.md
+++ b/docs/superpowers/specs/2026-03-23-performance-testing-design.md
@@ -28,25 +28,29 @@ performance/
     stress.js        # ramp 1→200→0 VUs, 10min — find degradation point
     soak.js          # 20 VUs steady, 30min — memory leaks / connection exhaustion
     spike.js         # 0→500→0 VUs, 2min — resilience under sudden burst
-  thresholds/
-    ci.json          # strict: p95 < 500ms, error rate < 1%, checks > 99%
-    local.json       # relaxed: p95 < 1s
   reports/           # gitignored — JSON + HTML output
-  docker-compose.perf.yml   # full stack + k6 runner
-  run.sh             # ./run.sh <scenario> [BASE_URL]
-  README.md
+  docker-compose.perf.yml   # full stack (dedicated perf DB) + k6 runner
+  run.sh             # ./run.sh <scenario> [BASE_URL] — propagates k6 exit code
+  README.md          # includes warnings for resource-intensive scenarios
 .github/workflows/perf.yml
 ```
+
+> Note: No `thresholds/` directory — thresholds are embedded inside each scenario's `options` export and switched via `__ENV.CI` environment variable (see Thresholds section).
 
 ---
 
 ## Shared Library Design
 
 ### `lib/auth.js`
-Handles per-VU user lifecycle. Each VU registers a unique test user (e.g., `user_perf_<vuId>`) and logs in once during the VU init stage. The token is reused across all iterations for that VU — mirroring real user behavior.
+Handles per-VU user lifecycle. Each VU calls `registerAndLogin(baseUrl, vuId)` at the **start of its first `default()` iteration** (guarded by a flag in VU state). This function:
+1. Sends `POST /auth/register` with JSON body `{ username: "user_perf_<vuId>", password: "..." }`
+2. Sends `POST /auth/login` with **`application/x-www-form-urlencoded`** body (`username=...&password=...`) — required because the backend uses FastAPI's `OAuth2PasswordRequestForm`
+3. Returns the JWT token, stored in VU scope and reused for all subsequent iterations
+
+> Important: Registration uses JSON; login uses form encoding. These two endpoints have different `Content-Type` requirements.
 
 ### `lib/client.js`
-Thin wrapper around k6's `http` module. Pre-sets the `Authorization: Bearer <token>` header and base URL. All scenarios import this instead of using raw `http` calls, ensuring consistent headers and default response checks.
+Thin wrapper around k6's `http` module. Pre-sets the `Authorization: Bearer <token>` header and base URL. All scenarios import this instead of using raw `http` calls.
 
 ### `lib/data.js`
 Generates deterministic todo payloads using `vuId` and iteration index to ensure unique titles across parallel VUs. Prevents unique constraint violations and data collisions during concurrent runs.
@@ -57,12 +61,28 @@ Generates deterministic todo payloads using `vuId` and iteration index to ensure
 
 | Stage | Function | Purpose |
 |---|---|---|
-| Init | VU-level code (top of file) | Each VU registers its own user and logs in; token stored in VU scope |
-| Setup | `setup()` | Global one-time prep (shared test data if needed in future) |
-| Test loop | `default(data)` | CRUD operations only — no auth overhead in measurements |
-| Teardown | `teardown(data)` | Delete test users and todos created during the run |
+| Default (first iter) | `default()` with VU-scope guard | Each VU registers its own user and logs in; token stored in VU variable. HTTP is only permitted here, not in the init stage. |
+| Test loop | `default()` subsequent iterations | CRUD operations only — no auth overhead in measurements |
+| Teardown | `teardown()` | Cleans up todos created during the run (see Database Isolation below) |
 
-This ensures registration and login costs are completely excluded from latency measurements.
+> Note: k6's init stage (top-level script code) **prohibits HTTP requests**. All network calls must be inside `default()` or `teardown()`. `setup()` is omitted — there is no global shared state needed at this stage.
+
+---
+
+## Database Isolation
+
+`docker-compose.perf.yml` uses a **dedicated `postgres_perf` service** with database `tododb_perf` — separate from the development `postgres` service. This follows the same pattern as `docker-compose.e2e.yml`.
+
+**Why:** Running against the shared dev database would pollute it with perf test users and todos.
+
+**Test user cleanup:** The backend has no admin delete-user endpoint. Test users (created with username pattern `user_perf_<vuId>`) are not deleted. Todos are also not deleted — k6's `teardown()` runs in a separate context after all VUs finish and has no access to VU-scoped todo IDs, making reliable per-todo cleanup impractical without a shared-state mechanism.
+
+This is acceptable because:
+- The `postgres_perf` database is ephemeral — its volume can be pruned between local profiling sessions with `docker compose -f docker-compose.perf.yml down -v`
+- CI always starts with a fresh `postgres_perf` container (no persistent volume between runs)
+- `teardown()` is omitted entirely; the function does not exist in scenario scripts
+
+**Repeated local runs:** `lib/auth.js` must handle `POST /auth/register` returning `409 Conflict` (username already taken from a prior run). When a 409 is received, the function skips registration and proceeds directly to login. This allows local reruns against a persistent perf volume without manual cleanup.
 
 ---
 
@@ -82,6 +102,8 @@ All scenarios execute the same per-iteration user journey:
 | `soak` | 20 steady | 30min | Detect memory leaks, connection exhaustion |
 | `spike` | 0→500→0 | 2min | Resilience under sudden burst |
 
+> **Warning:** `stress` and `spike` scenarios are resource-intensive. They should be run on a server or CI environment with adequate resources, not on a developer laptop. See README for guidance.
+
 ---
 
 ## Assertions: Checks + Thresholds
@@ -95,34 +117,73 @@ check(response, {
   'title matches':   (r) => r.json('title') === payload.title,
 });
 ```
-Auth endpoints also check token presence and format.
+Auth endpoints check for token presence and correct response shape.
 
 ### Thresholds (aggregate pass/fail gates)
-Defined in `thresholds/ci.json`, applied in CI:
-- `http_req_duration p(95) < 500ms`
-- `http_req_failed rate < 1%`
-- `checks pass rate > 99%`
+Thresholds are embedded in each scenario's exported `options` object. Strict (CI) vs. relaxed (local) values are selected via the `__ENV.CI` environment variable:
 
-Relaxed values in `thresholds/local.json` for developer machines.
+```js
+export const options = {
+  thresholds: {
+    http_req_duration: [__ENV.CI ? 'p(95)<500' : 'p(95)<1000'],
+    http_req_failed:   [__ENV.CI ? 'rate<0.01' : 'rate<0.05'],
+    checks:            [__ENV.CI ? 'rate>0.99' : 'rate>0.95'],
+  },
+};
+```
+
+CI sets `--env CI=true`. Local runs omit it, getting relaxed values.
 
 ---
 
 ## Infrastructure
 
+### k6 Version
+Both `docker-compose.perf.yml` and `perf.yml` pin to `grafana/k6:0.54.0` to ensure reproducible behavior.
+
 ### Local run via Docker Compose
-`docker-compose.perf.yml` extends the existing `docker-compose.yml`, adding a k6 service that targets the backend container directly:
+`docker-compose.perf.yml` defines a dedicated perf stack with its own database:
 
 ```yaml
 services:
+  postgres_perf:
+    image: postgres:13
+    environment:
+      - POSTGRES_USER=user
+      - POSTGRES_PASSWORD=password
+      - POSTGRES_DB=tododb_perf
+    volumes:
+      - postgres_perf_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U user -d tododb_perf"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+  backend_perf:
+    build:
+      context: ./backend
+    environment:
+      - DATABASE_URL=postgresql+asyncpg://user:password@postgres_perf/tododb_perf
+      - SECRET_KEY=perf-test-secret-key
+    depends_on:
+      postgres_perf:
+        condition: service_healthy
+
   k6:
-    image: grafana/k6
+    image: grafana/k6:0.54.0
     volumes:
       - ./performance:/scripts
+      - ./performance/reports:/reports
     environment:
-      - BASE_URL=http://backend:8000
-    command: run /scripts/scenarios/smoke.js
+      - BASE_URL=http://backend_perf:8000
+    command: run /scripts/scenarios/smoke.js --out json=/reports/result.json
     depends_on:
-      - backend
+      - backend_perf
+
+volumes:
+  postgres_perf_data:
 ```
 
 ### `run.sh` — local runner
@@ -132,20 +193,17 @@ services:
 ./run.sh stress                            # local, stress scenario
 ```
 
-Accepts an optional `BASE_URL` argument to target any deployed environment.
+- Accepts an optional `BASE_URL` argument to target any deployed environment
+- **Propagates k6's exit code without modification** — a threshold breach exits non-zero, giving a clear signal before pushing
 
 ### GitHub Actions (`perf.yml`)
 - **Trigger:** PR to main + push to main
 - **Steps:**
-  1. `docker compose up` (postgres + backend)
-  2. `k6 run scenarios/smoke.js --env BASE_URL=http://localhost:8000 --thresholds-file thresholds/ci.json`
-  3. Upload `reports/smoke-result.json` as a build artifact
-  4. Exit non-zero (fail PR) if any threshold is breached
-
-### Reports
-- JSON output → `reports/` (gitignored, not committed)
-- CI artifacts stored per run for trend comparison
-- `handleSummary()` in each scenario generates a human-readable HTML report
+  1. `docker compose -f docker-compose.perf.yml up -d postgres_perf backend_perf`
+  2. Wait for backend health check
+  3. `docker compose -f docker-compose.perf.yml run --env CI=true --env BASE_URL=http://backend_perf:8000 k6 run /scripts/scenarios/smoke.js --out json=/reports/smoke-result.json`
+  4. Upload `reports/smoke-result.json` as a build artifact (`retention-days: 30`)
+  5. Exit non-zero (fail PR) if k6 exits non-zero (threshold breached)
 
 ---
 

--- a/docs/superpowers/specs/2026-03-23-performance-testing-design.md
+++ b/docs/superpowers/specs/2026-03-23-performance-testing-design.md
@@ -1,0 +1,156 @@
+# Performance Testing Framework Design
+
+**Date:** 2026-03-23
+**Status:** Approved
+**Tool:** k6
+**Location:** `/performance/` inside this repository
+
+---
+
+## Goals
+
+1. **Regression detection** — smoke test runs in CI on every PR to main; fails the build if thresholds are breached
+2. **Capacity profiling** — load, stress, soak, and spike scenarios run on demand locally or against a deployed environment
+
+---
+
+## Directory Structure
+
+```
+performance/
+  lib/
+    auth.js          # per-VU user registration + login, returns token
+    client.js        # base HTTP client with Authorization header pre-set
+    data.js          # deterministic todo payload generators (vuId + iter)
+  scenarios/
+    smoke.js         # 1 VU, 30s — sanity check all endpoints
+    load.js          # ramp 1→50→0 VUs, 5min — normal expected load
+    stress.js        # ramp 1→200→0 VUs, 10min — find degradation point
+    soak.js          # 20 VUs steady, 30min — memory leaks / connection exhaustion
+    spike.js         # 0→500→0 VUs, 2min — resilience under sudden burst
+  thresholds/
+    ci.json          # strict: p95 < 500ms, error rate < 1%, checks > 99%
+    local.json       # relaxed: p95 < 1s
+  reports/           # gitignored — JSON + HTML output
+  docker-compose.perf.yml   # full stack + k6 runner
+  run.sh             # ./run.sh <scenario> [BASE_URL]
+  README.md
+.github/workflows/perf.yml
+```
+
+---
+
+## Shared Library Design
+
+### `lib/auth.js`
+Handles per-VU user lifecycle. Each VU registers a unique test user (e.g., `user_perf_<vuId>`) and logs in once during the VU init stage. The token is reused across all iterations for that VU — mirroring real user behavior.
+
+### `lib/client.js`
+Thin wrapper around k6's `http` module. Pre-sets the `Authorization: Bearer <token>` header and base URL. All scenarios import this instead of using raw `http` calls, ensuring consistent headers and default response checks.
+
+### `lib/data.js`
+Generates deterministic todo payloads using `vuId` and iteration index to ensure unique titles across parallel VUs. Prevents unique constraint violations and data collisions during concurrent runs.
+
+---
+
+## k6 Lifecycle Stages
+
+| Stage | Function | Purpose |
+|---|---|---|
+| Init | VU-level code (top of file) | Each VU registers its own user and logs in; token stored in VU scope |
+| Setup | `setup()` | Global one-time prep (shared test data if needed in future) |
+| Test loop | `default(data)` | CRUD operations only — no auth overhead in measurements |
+| Teardown | `teardown(data)` | Delete test users and todos created during the run |
+
+This ensures registration and login costs are completely excluded from latency measurements.
+
+---
+
+## Scenario Design
+
+All scenarios execute the same per-iteration user journey:
+1. `GET /todos` — list todos
+2. `POST /todos` — create a todo
+3. `PUT /todos/{id}` — update the created todo
+4. `DELETE /todos/{id}` — delete the todo
+
+| Scenario | VUs | Duration | Purpose |
+|---|---|---|---|
+| `smoke` | 1 | 30s | Verify all endpoints work before heavier runs |
+| `load` | ramp 1→50→0 | 5min | Baseline — normal expected traffic |
+| `stress` | ramp 1→200→0 | 10min | Find degradation/breaking point |
+| `soak` | 20 steady | 30min | Detect memory leaks, connection exhaustion |
+| `spike` | 0→500→0 | 2min | Resilience under sudden burst |
+
+---
+
+## Assertions: Checks + Thresholds
+
+### Per-request checks (inline assertions)
+Every request includes response checks:
+```js
+check(response, {
+  'status is 201':   (r) => r.status === 201,
+  'has todo id':     (r) => r.json('id') !== undefined,
+  'title matches':   (r) => r.json('title') === payload.title,
+});
+```
+Auth endpoints also check token presence and format.
+
+### Thresholds (aggregate pass/fail gates)
+Defined in `thresholds/ci.json`, applied in CI:
+- `http_req_duration p(95) < 500ms`
+- `http_req_failed rate < 1%`
+- `checks pass rate > 99%`
+
+Relaxed values in `thresholds/local.json` for developer machines.
+
+---
+
+## Infrastructure
+
+### Local run via Docker Compose
+`docker-compose.perf.yml` extends the existing `docker-compose.yml`, adding a k6 service that targets the backend container directly:
+
+```yaml
+services:
+  k6:
+    image: grafana/k6
+    volumes:
+      - ./performance:/scripts
+    environment:
+      - BASE_URL=http://backend:8000
+    command: run /scripts/scenarios/smoke.js
+    depends_on:
+      - backend
+```
+
+### `run.sh` — local runner
+```bash
+./run.sh smoke                             # local Docker stack
+./run.sh load https://staging.myapp.com   # against deployed env
+./run.sh stress                            # local, stress scenario
+```
+
+Accepts an optional `BASE_URL` argument to target any deployed environment.
+
+### GitHub Actions (`perf.yml`)
+- **Trigger:** PR to main + push to main
+- **Steps:**
+  1. `docker compose up` (postgres + backend)
+  2. `k6 run scenarios/smoke.js --env BASE_URL=http://localhost:8000 --thresholds-file thresholds/ci.json`
+  3. Upload `reports/smoke-result.json` as a build artifact
+  4. Exit non-zero (fail PR) if any threshold is breached
+
+### Reports
+- JSON output → `reports/` (gitignored, not committed)
+- CI artifacts stored per run for trend comparison
+- `handleSummary()` in each scenario generates a human-readable HTML report
+
+---
+
+## Development Approach
+
+- Branch: `feature/performance-framework`
+- Developed in a git worktree for isolation from other in-progress work
+- Added to existing repo under `/performance/` — keeps perf tests in sync with API changes

--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+playwright-report/
+test-results/
+.auth/

--- a/e2e/fixtures/api.fixture.ts
+++ b/e2e/fixtures/api.fixture.ts
@@ -56,7 +56,7 @@ export class ApiFixture {
         method: 'DELETE',
         headers: { Authorization: `Bearer ${token}` },
       });
-      if (!deleteRes.ok) {
+      if (!deleteRes.ok && deleteRes.status !== 404) {
         throw new Error(`clearTodos delete ${todo.id} failed: ${deleteRes.status}`);
       }
     }

--- a/e2e/fixtures/api.fixture.ts
+++ b/e2e/fixtures/api.fixture.ts
@@ -52,15 +52,22 @@ export class ApiFixture {
     if (!res.ok) throw new Error(`clearTodos list failed: ${res.status}`);
     const todos: TodoItem[] = await res.json();
     for (const todo of todos) {
-      await fetch(`${BACKEND_URL}/todos/${todo.id}`, {
+      const deleteRes = await fetch(`${BACKEND_URL}/todos/${todo.id}`, {
         method: 'DELETE',
         headers: { Authorization: `Bearer ${token}` },
       });
+      if (!deleteRes.ok) {
+        throw new Error(`clearTodos delete ${todo.id} failed: ${deleteRes.status}`);
+      }
     }
   }
 
+  /**
+   * Registers a new user and returns their JWT token.
+   * Note: this token belongs to the new user, NOT to TEST_USER.
+   * ApiFixture.createTodo/clearTodos continue to use TEST_USER's token.
+   */
   async registerUser(username: string, password: string): Promise<string> {
-    // Returns JWT token for the new user
     const res = await fetch(`${BACKEND_URL}/auth/register`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },

--- a/e2e/fixtures/api.fixture.ts
+++ b/e2e/fixtures/api.fixture.ts
@@ -1,0 +1,73 @@
+// e2e/fixtures/api.fixture.ts
+import { TEST_USER, BACKEND_URL } from '../test-constants';
+
+interface TodoItem {
+  id: number;
+  title: string;
+  completed: boolean;
+  type: string;
+}
+
+export class ApiFixture {
+  private token: string | null = null;
+
+  private async getToken(): Promise<string> {
+    if (this.token) return this.token;
+
+    // /auth/login requires application/x-www-form-urlencoded (FastAPI OAuth2PasswordRequestForm)
+    const res = await fetch(`${BACKEND_URL}/auth/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        username: TEST_USER.username,
+        password: TEST_USER.password,
+      }),
+    });
+    if (!res.ok) throw new Error(`ApiFixture login failed: ${res.status}`);
+    const data = await res.json();
+    this.token = data.access_token;
+    return this.token!;
+  }
+
+  async createTodo(title: string, type: 'todo' | 'timeline' = 'todo'): Promise<TodoItem> {
+    const token = await this.getToken();
+    const res = await fetch(`${BACKEND_URL}/todos`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ title, type }),
+    });
+    if (!res.ok) throw new Error(`createTodo failed: ${res.status}`);
+    return res.json();
+  }
+
+  async clearTodos(): Promise<void> {
+    const token = await this.getToken();
+    // No bulk-delete endpoint — must list then delete individually
+    const res = await fetch(`${BACKEND_URL}/todos`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!res.ok) throw new Error(`clearTodos list failed: ${res.status}`);
+    const todos: TodoItem[] = await res.json();
+    for (const todo of todos) {
+      await fetch(`${BACKEND_URL}/todos/${todo.id}`, {
+        method: 'DELETE',
+        headers: { Authorization: `Bearer ${token}` },
+      });
+    }
+  }
+
+  async registerUser(username: string, password: string): Promise<string> {
+    // Returns JWT token for the new user
+    const res = await fetch(`${BACKEND_URL}/auth/register`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password }),
+    });
+    if (!res.ok) throw new Error(`registerUser failed: ${res.status}`);
+    const data = await res.json();
+    return data.access_token;
+  }
+}

--- a/e2e/fixtures/auth.fixture.ts
+++ b/e2e/fixtures/auth.fixture.ts
@@ -1,8 +1,6 @@
 // e2e/fixtures/auth.fixture.ts
 import { test as base, BrowserContext, Page } from '@playwright/test';
-import * as path from 'path';
-
-const AUTH_FILE = path.join(__dirname, '../.auth/user.json');
+import { AUTH_FILE } from '../test-constants';
 
 type AuthFixtures = {
   authenticatedPage: Page;
@@ -18,7 +16,7 @@ export const test = base.extend<AuthFixtures>({
   authenticatedPage: async ({ authenticatedContext }, use) => {
     const page = await authenticatedContext.newPage();
     await use(page);
-    await page.close();
+    await page.close(); // explicit close before context ensures proper Playwright teardown ordering
   },
 });
 

--- a/e2e/fixtures/auth.fixture.ts
+++ b/e2e/fixtures/auth.fixture.ts
@@ -1,15 +1,34 @@
 // e2e/fixtures/auth.fixture.ts
 import { test as base, BrowserContext, Page } from '@playwright/test';
-import { AUTH_FILE } from '../test-constants';
+import { TEST_USER, BACKEND_URL } from '../test-constants';
 
 type AuthFixtures = {
   authenticatedPage: Page;
   authenticatedContext: BrowserContext;
 };
 
+async function getTestToken(): Promise<string> {
+  const res = await fetch(`${BACKEND_URL}/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      username: TEST_USER.username,
+      password: TEST_USER.password,
+    }),
+  });
+  if (!res.ok) throw new Error(`auth.fixture login failed: ${res.status}`);
+  const data = await res.json();
+  return data.access_token;
+}
+
 export const test = base.extend<AuthFixtures>({
   authenticatedContext: async ({ browser }, use) => {
-    const context = await browser.newContext({ storageState: AUTH_FILE });
+    const token = await getTestToken();
+    const context = await browser.newContext();
+    // Inject the token into sessionStorage before any page script runs
+    await context.addInitScript((t: string) => {
+      sessionStorage.setItem('token', t);
+    }, token);
     await use(context);
     await context.close();
   },

--- a/e2e/fixtures/auth.fixture.ts
+++ b/e2e/fixtures/auth.fixture.ts
@@ -1,0 +1,25 @@
+// e2e/fixtures/auth.fixture.ts
+import { test as base, BrowserContext, Page } from '@playwright/test';
+import * as path from 'path';
+
+const AUTH_FILE = path.join(__dirname, '../.auth/user.json');
+
+type AuthFixtures = {
+  authenticatedPage: Page;
+  authenticatedContext: BrowserContext;
+};
+
+export const test = base.extend<AuthFixtures>({
+  authenticatedContext: async ({ browser }, use) => {
+    const context = await browser.newContext({ storageState: AUTH_FILE });
+    await use(context);
+    await context.close();
+  },
+  authenticatedPage: async ({ authenticatedContext }, use) => {
+    const page = await authenticatedContext.newPage();
+    await use(page);
+    await page.close();
+  },
+});
+
+export { expect } from '@playwright/test';

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,10 +1,7 @@
-// e2e/global-setup.ts
-import { chromium, FullConfig } from '@playwright/test';
-import * as fs from 'fs';
+import { FullConfig } from '@playwright/test';
 import * as path from 'path';
 import { TEST_USER, BACKEND_URL, FRONTEND_URL } from './test-constants';
 
-const AUTH_FILE = path.join(__dirname, '.auth/user.json');
 const POLL_INTERVAL_MS = 2000;
 const TIMEOUT_MS = 60_000;
 
@@ -37,32 +34,8 @@ async function ensureTestUserExists(): Promise<void> {
 }
 
 export default async function globalSetup(_config: FullConfig) {
-  // 1. Wait for both services to be healthy
   await waitForService(`${BACKEND_URL}/`, 'backend');
   await waitForService(FRONTEND_URL, 'frontend');
-
-  // 2. Ensure the test user exists in the DB
   await ensureTestUserExists();
-
-  // 3. Log in via the UI and save storageState (captures sessionStorage with token)
-  fs.mkdirSync(path.dirname(AUTH_FILE), { recursive: true });
-
-  const browser = await chromium.launch();
-  try {
-    const context = await browser.newContext();
-    const page = await context.newPage();
-
-    await page.goto(FRONTEND_URL);
-    await page.getByPlaceholder('Username').fill(TEST_USER.username);
-    await page.getByPlaceholder('Password').fill(TEST_USER.password);
-    await page.getByRole('button', { name: 'Log In' }).click();
-
-    await page.getByPlaceholder('Add a new task...').waitFor({ timeout: 15_000 });
-
-    await context.storageState({ path: AUTH_FILE });
-  } finally {
-    await browser.close();
-  }
-
-  console.log('[global-setup] storageState saved to', AUTH_FILE);
+  console.log('[global-setup] services ready, test user ensured');
 }

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -20,7 +20,9 @@ async function waitForService(url: string, label: string): Promise<void> {
     } catch {
       // not ready yet — swallow and retry
     }
-    await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+    if (Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+    }
   }
   throw new Error(`[global-setup] Timed out after ${TIMEOUT_MS}ms waiting for ${label} at ${url}`);
 }
@@ -46,19 +48,21 @@ export default async function globalSetup(_config: FullConfig) {
   fs.mkdirSync(path.dirname(AUTH_FILE), { recursive: true });
 
   const browser = await chromium.launch();
-  const context = await browser.newContext();
-  const page = await context.newPage();
+  try {
+    const context = await browser.newContext();
+    const page = await context.newPage();
 
-  await page.goto(FRONTEND_URL);
-  await page.getByPlaceholder('Username').fill(TEST_USER.username);
-  await page.getByPlaceholder('Password').fill(TEST_USER.password);
-  await page.getByRole('button', { name: 'Log In' }).click();
+    await page.goto(FRONTEND_URL);
+    await page.getByPlaceholder('Username').fill(TEST_USER.username);
+    await page.getByPlaceholder('Password').fill(TEST_USER.password);
+    await page.getByRole('button', { name: 'Log In' }).click();
 
-  // Wait until past the auth gate
-  await page.getByPlaceholder('Add a new task...').waitFor({ timeout: 15_000 });
+    await page.getByPlaceholder('Add a new task...').waitFor({ timeout: 15_000 });
 
-  await context.storageState({ path: AUTH_FILE });
-  await browser.close();
+    await context.storageState({ path: AUTH_FILE });
+  } finally {
+    await browser.close();
+  }
 
   console.log('[global-setup] storageState saved to', AUTH_FILE);
 }

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,0 +1,64 @@
+// e2e/global-setup.ts
+import { chromium, FullConfig } from '@playwright/test';
+import * as fs from 'fs';
+import * as path from 'path';
+import { TEST_USER, BACKEND_URL, FRONTEND_URL } from './test-constants';
+
+const AUTH_FILE = path.join(__dirname, '.auth/user.json');
+const POLL_INTERVAL_MS = 2000;
+const TIMEOUT_MS = 60_000;
+
+async function waitForService(url: string, label: string): Promise<void> {
+  const deadline = Date.now() + TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(url);
+      if (res.ok) {
+        console.log(`[global-setup] ${label} ready`);
+        return;
+      }
+    } catch {
+      // not ready yet — swallow and retry
+    }
+    await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+  }
+  throw new Error(`[global-setup] Timed out after ${TIMEOUT_MS}ms waiting for ${label} at ${url}`);
+}
+
+async function ensureTestUserExists(): Promise<void> {
+  // Register — ignore 409 if user already exists
+  await fetch(`${BACKEND_URL}/auth/register`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username: TEST_USER.username, password: TEST_USER.password }),
+  });
+}
+
+export default async function globalSetup(_config: FullConfig) {
+  // 1. Wait for both services to be healthy
+  await waitForService(`${BACKEND_URL}/`, 'backend');
+  await waitForService(FRONTEND_URL, 'frontend');
+
+  // 2. Ensure the test user exists in the DB
+  await ensureTestUserExists();
+
+  // 3. Log in via the UI and save storageState (captures sessionStorage with token)
+  fs.mkdirSync(path.dirname(AUTH_FILE), { recursive: true });
+
+  const browser = await chromium.launch();
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  await page.goto(FRONTEND_URL);
+  await page.getByPlaceholder('Username').fill(TEST_USER.username);
+  await page.getByPlaceholder('Password').fill(TEST_USER.password);
+  await page.getByRole('button', { name: 'Log In' }).click();
+
+  // Wait until past the auth gate
+  await page.getByPlaceholder('Add a new task...').waitFor({ timeout: 15_000 });
+
+  await context.storageState({ path: AUTH_FILE });
+  await browser.close();
+
+  console.log('[global-setup] storageState saved to', AUTH_FILE);
+}

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -1,0 +1,93 @@
+{
+  "name": "todo-e2e",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "todo-e2e",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@playwright/test": "^1.40.0",
+        "typescript": "^5.0.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -9,7 +9,7 @@
     "report": "playwright show-report"
   },
   "devDependencies": {
-    "@playwright/test": "^1.40.0",
+    "@playwright/test": "^1.58.0",
     "typescript": "^5.0.0"
   }
 }

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "todo-e2e",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "test": "playwright test",
+    "test:smoke": "playwright test --grep @smoke",
+    "test:headed": "playwright test --headed",
+    "report": "playwright show-report"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.40.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/e2e/pages/AuthPage.ts
+++ b/e2e/pages/AuthPage.ts
@@ -1,0 +1,31 @@
+// e2e/pages/AuthPage.ts
+import { Page, expect } from '@playwright/test';
+
+export class AuthPage {
+  constructor(private page: Page) {}
+
+  async login(username: string, password: string) {
+    await this.page.getByPlaceholder('Username').fill(username);
+    await this.page.getByPlaceholder('Password').fill(password);
+    await this.page.getByRole('button', { name: 'Log In' }).click();
+  }
+
+  async register(username: string, password: string) {
+    await this.page.getByRole('button', { name: 'Switch to Register' }).click();
+    await this.page.getByPlaceholder('Username').fill(username);
+    await this.page.getByPlaceholder('Password').fill(password);
+    await this.page.getByRole('button', { name: 'Register' }).click();
+  }
+
+  async expectError(message: string) {
+    await expect(this.page.locator('.auth-error')).toHaveText(message);
+  }
+
+  async expectTodoFormVisible() {
+    await expect(this.page.getByPlaceholder('Add a new task...')).toBeVisible();
+  }
+
+  async expectAuthFormVisible() {
+    await expect(this.page.getByPlaceholder('Username')).toBeVisible();
+  }
+}

--- a/e2e/pages/AuthPage.ts
+++ b/e2e/pages/AuthPage.ts
@@ -21,10 +21,6 @@ export class AuthPage {
     await expect(this.page.locator('.auth-error')).toHaveText(message);
   }
 
-  async expectTodoFormVisible() {
-    await expect(this.page.getByPlaceholder('Add a new task...')).toBeVisible();
-  }
-
   async expectAuthFormVisible() {
     await expect(this.page.getByPlaceholder('Username')).toBeVisible();
   }

--- a/e2e/pages/TodoPage.ts
+++ b/e2e/pages/TodoPage.ts
@@ -11,7 +11,8 @@ export class TodoPage {
       await this.page.getByRole('combobox').selectOption('timeline');
     }
     await this.page.getByRole('button', { name: 'Add' }).click();
-    // Reset select back to 'todo' for next call (avoids state leaking between actions)
+    // Wait for the item to appear before resetting select to avoid race condition
+    await this.page.getByPlaceholder('Add a new task...').waitFor({ state: 'visible' });
     if (type === 'timeline') {
       await this.page.getByRole('combobox').selectOption('todo');
     }
@@ -54,5 +55,9 @@ export class TodoPage {
 
   async logout() {
     await this.page.getByRole('button', { name: 'Logout' }).click();
+  }
+
+  async expectFormVisible() {
+    await expect(this.page.getByPlaceholder('Add a new task...')).toBeVisible();
   }
 }

--- a/e2e/pages/TodoPage.ts
+++ b/e2e/pages/TodoPage.ts
@@ -35,7 +35,7 @@ export class TodoPage {
   }
 
   async expectTodoNotVisible(text: string) {
-    await expect(this.todoRow(text)).not.toBeVisible();
+    await expect(this.todoRow(text)).not.toBeAttached();
   }
 
   async expectCompleted(text: string) {

--- a/e2e/pages/TodoPage.ts
+++ b/e2e/pages/TodoPage.ts
@@ -1,0 +1,58 @@
+// e2e/pages/TodoPage.ts
+import { Page, Locator, expect } from '@playwright/test';
+
+export class TodoPage {
+  constructor(private page: Page) {}
+
+  async addTodo(text: string, type: 'todo' | 'timeline' = 'todo') {
+    await this.page.getByPlaceholder('Add a new task...').fill(text);
+    // Select is always rendered; default is 'todo' — only change when needed
+    if (type === 'timeline') {
+      await this.page.getByRole('combobox').selectOption('timeline');
+    }
+    await this.page.getByRole('button', { name: 'Add' }).click();
+    // Reset select back to 'todo' for next call (avoids state leaking between actions)
+    if (type === 'timeline') {
+      await this.page.getByRole('combobox').selectOption('todo');
+    }
+  }
+
+  private todoRow(text: string): Locator {
+    return this.page.locator('.todo-item').filter({ hasText: text });
+  }
+
+  async toggleTodo(text: string) {
+    await this.todoRow(text).getByRole('checkbox').click();
+  }
+
+  async deleteTodo(text: string) {
+    await this.todoRow(text).getByRole('button', { name: 'Delete' }).click();
+  }
+
+  async expectTodoVisible(text: string) {
+    await expect(this.todoRow(text)).toBeVisible();
+  }
+
+  async expectTodoNotVisible(text: string) {
+    await expect(this.todoRow(text)).not.toBeVisible();
+  }
+
+  async expectCompleted(text: string) {
+    // The inline style 'text-decoration: line-through' is on the first child div of .todo-item
+    await expect(
+      this.todoRow(text).locator('> div:first-child'),
+    ).toHaveCSS('text-decoration', /line-through/);
+  }
+
+  async switchToTimeline() {
+    await this.page.getByRole('tab', { name: 'Timeline' }).click();
+  }
+
+  async expectTimelineTabVisible() {
+    await expect(this.page.getByRole('tab', { name: 'Timeline' })).toBeVisible();
+  }
+
+  async logout() {
+    await this.page.getByRole('button', { name: 'Logout' }).click();
+  }
+}

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  globalSetup: './global-setup',
+  retries: process.env.CI ? 1 : 0,
+  reporter: [['html', { open: 'never' }], ['list']],
+  use: {
+    baseURL: 'http://localhost:3000',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -3,11 +3,13 @@ import { defineConfig, devices } from '@playwright/test';
 export default defineConfig({
   testDir: './tests',
   globalSetup: './global-setup',
+  timeout: 30_000,
   retries: process.env.CI ? 1 : 0,
   reporter: [['html', { open: 'never' }], ['list']],
   use: {
     baseURL: 'http://localhost:3000',
     trace: 'on-first-retry',
+    actionTimeout: 10_000,
   },
   projects: [
     {

--- a/e2e/test-constants.ts
+++ b/e2e/test-constants.ts
@@ -1,3 +1,7 @@
+import * as path from 'path';
+
+export const AUTH_FILE = path.join(__dirname, '.auth/user.json');
+
 export const TEST_USER = {
   username: 'e2e-testuser',
   password: 'e2e-password-42',

--- a/e2e/test-constants.ts
+++ b/e2e/test-constants.ts
@@ -1,0 +1,7 @@
+export const TEST_USER = {
+  username: 'e2e-testuser',
+  password: 'e2e-password-42',
+};
+
+export const BACKEND_URL = 'http://localhost:8000';
+export const FRONTEND_URL = 'http://localhost:3000';

--- a/e2e/tests/auth.spec.ts
+++ b/e2e/tests/auth.spec.ts
@@ -1,15 +1,12 @@
 // e2e/tests/auth.spec.ts
-import * as path from 'path';
 import { test, expect } from '@playwright/test';
 import { AuthPage } from '../pages/AuthPage';
 import { TodoPage } from '../pages/TodoPage';
 import { FRONTEND_URL } from '../test-constants';
 
-// Unique suffix per test run prevents username collisions when rerunning without DB wipe
-const runId = Date.now();
-
 test.describe('Authentication', () => {
   test('@smoke register a new user and land on todo list', async ({ page }) => {
+    const runId = Date.now(); // inside the test to ensure uniqueness on retry
     const auth = new AuthPage(page);
     const todo = new TodoPage(page);
     await page.goto(FRONTEND_URL);
@@ -45,25 +42,28 @@ test.describe('Authentication', () => {
 
   test('401 from API clears session and shows login screen', async ({ browser }) => {
     // Start authenticated
-    const context = await browser.newContext({
-      storageState: path.join(__dirname, '../.auth/user.json'),
-    });
+    const { AUTH_FILE } = await import('../test-constants');
+    const context = await browser.newContext({ storageState: AUTH_FILE });
     const page = await context.newPage();
     const auth = new AuthPage(page);
-
-    await page.goto(FRONTEND_URL);
-    await auth.expectAuthFormVisible();  // storageState loads sessionStorage, so should be logged in...
-    // Actually: verify we DO see the todo form first
     const todo = new TodoPage(page);
-    await todo.expectFormVisible();
 
-    // Simulate token expiry by clearing sessionStorage (mimics what a 401 does)
-    await page.evaluate(() => sessionStorage.clear());
-    await page.reload();
+    try {
+      await page.goto(FRONTEND_URL);
+      await todo.expectFormVisible();
 
-    // App re-reads token from sessionStorage on mount — it is now null
-    await auth.expectAuthFormVisible();
+      // Intercept the next /todos request and return 401 to simulate token expiry
+      await page.route('**/todos', route =>
+        route.fulfill({ status: 401, body: JSON.stringify({ detail: 'Unauthorized' }) })
+      );
 
-    await context.close();
+      // Reload triggers fetchTodos which hits the intercepted route
+      await page.reload();
+
+      // App's handleUnauthorized clears the token and renders AuthForm
+      await auth.expectAuthFormVisible();
+    } finally {
+      await context.close();
+    }
   });
 });

--- a/e2e/tests/auth.spec.ts
+++ b/e2e/tests/auth.spec.ts
@@ -2,7 +2,7 @@
 import { test, expect } from '@playwright/test';
 import { AuthPage } from '../pages/AuthPage';
 import { TodoPage } from '../pages/TodoPage';
-import { FRONTEND_URL } from '../test-constants';
+import { FRONTEND_URL, TEST_USER } from '../test-constants';
 
 test.describe('Authentication', () => {
   test('@smoke register a new user and land on todo list', async ({ page }) => {
@@ -19,14 +19,14 @@ test.describe('Authentication', () => {
     const todo = new TodoPage(page);
     await page.goto(FRONTEND_URL);
     // Use the pre-created e2e test user (exists from global-setup)
-    await auth.login('e2e-testuser', 'e2e-password-42');
+    await auth.login(TEST_USER.username, TEST_USER.password);
     await todo.expectFormVisible();
   });
 
   test('login with wrong password shows error', async ({ page }) => {
     const auth = new AuthPage(page);
     await page.goto(FRONTEND_URL);
-    await auth.login('e2e-testuser', 'wrongpassword');
+    await auth.login(TEST_USER.username, 'wrongpassword');
     await auth.expectError('Invalid credentials');
   });
 
@@ -34,16 +34,23 @@ test.describe('Authentication', () => {
     const auth = new AuthPage(page);
     const todo = new TodoPage(page);
     await page.goto(FRONTEND_URL);
-    await auth.login('e2e-testuser', 'e2e-password-42');
+    await auth.login(TEST_USER.username, TEST_USER.password);
     await todo.expectFormVisible();
     await todo.logout();
     await auth.expectAuthFormVisible();
   });
 
   test('401 from API clears session and shows login screen', async ({ browser }) => {
-    // Start authenticated
-    const { AUTH_FILE } = await import('../test-constants');
-    const context = await browser.newContext({ storageState: AUTH_FILE });
+    // Start authenticated — inject token into sessionStorage since app uses sessionStorage
+    const { BACKEND_URL, TEST_USER } = await import('../test-constants');
+    const loginRes = await fetch(`${BACKEND_URL}/auth/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({ username: TEST_USER.username, password: TEST_USER.password }),
+    });
+    const { access_token } = await loginRes.json();
+    const context = await browser.newContext();
+    await context.addInitScript((t: string) => { sessionStorage.setItem('token', t); }, access_token);
     const page = await context.newPage();
     const auth = new AuthPage(page);
     const todo = new TodoPage(page);

--- a/e2e/tests/auth.spec.ts
+++ b/e2e/tests/auth.spec.ts
@@ -1,0 +1,69 @@
+// e2e/tests/auth.spec.ts
+import * as path from 'path';
+import { test, expect } from '@playwright/test';
+import { AuthPage } from '../pages/AuthPage';
+import { TodoPage } from '../pages/TodoPage';
+import { FRONTEND_URL } from '../test-constants';
+
+// Unique suffix per test run prevents username collisions when rerunning without DB wipe
+const runId = Date.now();
+
+test.describe('Authentication', () => {
+  test('@smoke register a new user and land on todo list', async ({ page }) => {
+    const auth = new AuthPage(page);
+    const todo = new TodoPage(page);
+    await page.goto(FRONTEND_URL);
+    await auth.register(`newuser-${runId}`, 'password123');
+    await todo.expectFormVisible();
+  });
+
+  test('@smoke login with valid credentials', async ({ page }) => {
+    const auth = new AuthPage(page);
+    const todo = new TodoPage(page);
+    await page.goto(FRONTEND_URL);
+    // Use the pre-created e2e test user (exists from global-setup)
+    await auth.login('e2e-testuser', 'e2e-password-42');
+    await todo.expectFormVisible();
+  });
+
+  test('login with wrong password shows error', async ({ page }) => {
+    const auth = new AuthPage(page);
+    await page.goto(FRONTEND_URL);
+    await auth.login('e2e-testuser', 'wrongpassword');
+    await auth.expectError('Invalid credentials');
+  });
+
+  test('logout returns to login screen', async ({ page }) => {
+    const auth = new AuthPage(page);
+    const todo = new TodoPage(page);
+    await page.goto(FRONTEND_URL);
+    await auth.login('e2e-testuser', 'e2e-password-42');
+    await todo.expectFormVisible();
+    await todo.logout();
+    await auth.expectAuthFormVisible();
+  });
+
+  test('401 from API clears session and shows login screen', async ({ browser }) => {
+    // Start authenticated
+    const context = await browser.newContext({
+      storageState: path.join(__dirname, '../.auth/user.json'),
+    });
+    const page = await context.newPage();
+    const auth = new AuthPage(page);
+
+    await page.goto(FRONTEND_URL);
+    await auth.expectAuthFormVisible();  // storageState loads sessionStorage, so should be logged in...
+    // Actually: verify we DO see the todo form first
+    const todo = new TodoPage(page);
+    await todo.expectFormVisible();
+
+    // Simulate token expiry by clearing sessionStorage (mimics what a 401 does)
+    await page.evaluate(() => sessionStorage.clear());
+    await page.reload();
+
+    // App re-reads token from sessionStorage on mount — it is now null
+    await auth.expectAuthFormVisible();
+
+    await context.close();
+  });
+});

--- a/e2e/tests/timeline.spec.ts
+++ b/e2e/tests/timeline.spec.ts
@@ -1,0 +1,33 @@
+// e2e/tests/timeline.spec.ts
+import { test, expect } from '../fixtures/auth.fixture';
+import { TodoPage } from '../pages/TodoPage';
+import { ApiFixture } from '../fixtures/api.fixture';
+import { FRONTEND_URL } from '../test-constants';
+
+const api = new ApiFixture();
+
+test.describe('Timeline tab', () => {
+  test.afterEach(async () => {
+    await api.clearTodos();
+  });
+
+  test('Timeline tab is visible when feature flag is on', async ({ authenticatedPage }) => {
+    const todo = new TodoPage(authenticatedPage);
+    await authenticatedPage.goto(FRONTEND_URL);
+    await todo.expectTimelineTabVisible();
+  });
+
+  test('timeline item appears in Timeline tab and not in To-Do tab', async ({ authenticatedPage }) => {
+    const todo = new TodoPage(authenticatedPage);
+    await authenticatedPage.goto(FRONTEND_URL);
+
+    await todo.addTodo('Q3 milestone', 'timeline');
+
+    // Item must NOT appear in To-Do tab (current tab)
+    await todo.expectTodoNotVisible('Q3 milestone');
+
+    // Item MUST appear in Timeline tab
+    await todo.switchToTimeline();
+    await expect(authenticatedPage.getByText('Q3 milestone')).toBeVisible();
+  });
+});

--- a/e2e/tests/timeline.spec.ts
+++ b/e2e/tests/timeline.spec.ts
@@ -5,6 +5,7 @@ import { ApiFixture } from '../fixtures/api.fixture';
 import { FRONTEND_URL } from '../test-constants';
 
 const api = new ApiFixture();
+// Note: api and authenticatedPage both operate as TEST_USER — they must stay in sync.
 
 test.describe('Timeline tab', () => {
   test.afterEach(async () => {

--- a/e2e/tests/todos.spec.ts
+++ b/e2e/tests/todos.spec.ts
@@ -1,6 +1,7 @@
 // e2e/tests/todos.spec.ts
 import { test, expect } from '../fixtures/auth.fixture';
 import { TodoPage } from '../pages/TodoPage';
+import { AuthPage } from '../pages/AuthPage';
 import { ApiFixture } from '../fixtures/api.fixture';
 import { FRONTEND_URL } from '../test-constants';
 
@@ -49,26 +50,23 @@ test.describe('Todo CRUD', () => {
   });
 
   test('User A todos are not visible to User B', async ({ browser }) => {
-    // User A already has todos (seeded via API)
     await api.createTodo('User A secret todo');
 
-    // Register User B (unique username per run)
     const runId = Date.now();
     await api.registerUser(`user-b-${runId}`, 'passwordB');
 
-    // Log in as User B via a fresh browser context (no storageState)
     const contextB = await browser.newContext();
-    const pageB = await contextB.newPage();
+    try {
+      const pageB = await contextB.newPage();
+      const authB = new AuthPage(pageB);
+      await pageB.goto(FRONTEND_URL);
+      await authB.login(`user-b-${runId}`, 'passwordB');
+      await pageB.getByPlaceholder('Add a new task...').waitFor();
 
-    await pageB.goto(FRONTEND_URL);
-    await pageB.getByPlaceholder('Username').fill(`user-b-${runId}`);
-    await pageB.getByPlaceholder('Password').fill('passwordB');
-    await pageB.getByRole('button', { name: 'Log In' }).click();
-    await pageB.getByPlaceholder('Add a new task...').waitFor();
-
-    // User A's todo must not appear in User B's view
-    await expect(pageB.locator('.todo-item')).toHaveCount(0);
-
-    await contextB.close();
+      // User A's todo must not appear in User B's view
+      await expect(pageB.locator('.todo-item')).toHaveCount(0);
+    } finally {
+      await contextB.close();
+    }
   });
 });

--- a/e2e/tests/todos.spec.ts
+++ b/e2e/tests/todos.spec.ts
@@ -1,0 +1,74 @@
+// e2e/tests/todos.spec.ts
+import { test, expect } from '../fixtures/auth.fixture';
+import { TodoPage } from '../pages/TodoPage';
+import { ApiFixture } from '../fixtures/api.fixture';
+import { FRONTEND_URL } from '../test-constants';
+
+const api = new ApiFixture();
+
+test.describe('Todo CRUD', () => {
+  test.afterEach(async () => {
+    await api.clearTodos();
+  });
+
+  test('@smoke add a todo and see it in the list', async ({ authenticatedPage }) => {
+    const todo = new TodoPage(authenticatedPage);
+    await authenticatedPage.goto(FRONTEND_URL);
+
+    await todo.addTodo('Buy milk');
+    await todo.expectTodoVisible('Buy milk');
+  });
+
+  test('@smoke complete a todo — checkbox checked and text struck through', async ({ authenticatedPage }) => {
+    await api.createTodo('Read a book');
+    const todo = new TodoPage(authenticatedPage);
+    await authenticatedPage.goto(FRONTEND_URL);
+
+    await todo.toggleTodo('Read a book');
+    await todo.expectCompleted('Read a book');
+  });
+
+  test('@smoke delete a todo — removed from list', async ({ authenticatedPage }) => {
+    await api.createTodo('Take out trash');
+    const todo = new TodoPage(authenticatedPage);
+    await authenticatedPage.goto(FRONTEND_URL);
+
+    await todo.deleteTodo('Take out trash');
+    await todo.expectTodoNotVisible('Take out trash');
+  });
+
+  test('delete one todo while others remain', async ({ authenticatedPage }) => {
+    await api.createTodo('Task A');
+    await api.createTodo('Task B');
+    const todo = new TodoPage(authenticatedPage);
+    await authenticatedPage.goto(FRONTEND_URL);
+
+    await todo.deleteTodo('Task A');
+    await todo.expectTodoNotVisible('Task A');
+    await todo.expectTodoVisible('Task B');
+  });
+
+  test('User A todos are not visible to User B', async ({ browser }) => {
+    // User A already has todos (seeded via API)
+    await api.createTodo('User A secret todo');
+
+    // Register User B (unique username per run)
+    const runId = Date.now();
+    await api.registerUser(`user-b-${runId}`, 'passwordB');
+
+    // Log in as User B via a fresh browser context (no storageState)
+    const contextB = await browser.newContext();
+    const pageB = await contextB.newPage();
+
+    await pageB.goto(FRONTEND_URL);
+    await pageB.getByPlaceholder('Username').fill(`user-b-${runId}`);
+    await pageB.getByPlaceholder('Password').fill('passwordB');
+    await pageB.getByRole('button', { name: 'Log In' }).click();
+    await pageB.getByPlaceholder('Add a new task...').waitFor();
+
+    // User A's todo must not appear in User B's view
+    await expect(pageB.locator('.todo-item')).toHaveCount(0);
+
+    await contextB.close();
+  });
+});

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "baseUrl": "."
+  },
+  "include": ["./**/*.ts"],
+  "exclude": ["node_modules", "playwright-report", "test-results"]
+}

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -102,6 +102,7 @@ describe('App Component', () => {
     await waitFor(() => {
       expect(screen.getByText('New Todo')).toBeInTheDocument();
     });
+    expect(api.addTodo).toHaveBeenCalledWith('New Todo', 'test-token', expect.any(Function), 'todo');
   });
 
   test('toggles todo completion', async () => {

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -35,6 +35,7 @@ const loginAndRender = async (todosResult: Todo[] = []) => {
 describe('App Component', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    sessionStorage.clear(); // prevent token bleed-through between tests
   });
 
   test('shows AuthForm when not authenticated', () => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,12 +10,20 @@ import 'react-tabs/style/react-tabs.css';
 import './App.css';
 
 const App: React.FC = () => {
-  const [token, setToken] = useState<string | null>(null);
+  const [token, setToken] = useState<string | null>(sessionStorage.getItem('token'));
   const [todos, setTodos] = useState<Todo[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const handleUnauthorized = () => setToken(null);
+  const handleUnauthorized = () => {
+    sessionStorage.removeItem('token');
+    setToken(null);
+  };
+
+  const handleAuth = (t: string) => {
+    sessionStorage.setItem('token', t);
+    setToken(t);
+  };
 
   useEffect(() => {
     if (token) fetchTodos();
@@ -35,10 +43,10 @@ const App: React.FC = () => {
     }
   };
 
-  const addTodo = async (text: string) => {
+  const addTodo = async (text: string, type: string = 'todo') => {
     if (!token) return;
     try {
-      const newTodo = await api.addTodo(text, token, handleUnauthorized);
+      const newTodo = await api.addTodo(text, token, handleUnauthorized, type);
       setTodos((prevTodos) => [...prevTodos, newTodo]);
     } catch (err) {
       setError('Failed to add todo.');
@@ -74,7 +82,7 @@ const App: React.FC = () => {
   };
 
   if (!token) {
-    return <AuthForm onAuth={setToken} />;
+    return <AuthForm onAuth={handleAuth} />;
   }
 
   if (loading) {
@@ -92,7 +100,7 @@ const App: React.FC = () => {
   return (
     <div className="app-container">
       <div style={{ display: 'flex', justifyContent: 'flex-end', padding: '8px 0 4px' }}>
-        <button className="logout-btn" onClick={() => setToken(null)}>Logout</button>
+        <button className="logout-btn" onClick={() => { sessionStorage.removeItem('token'); setToken(null); }}>Logout</button>
       </div>
       <Tabs>
         <TabList>

--- a/frontend/src/services/api.test.ts
+++ b/frontend/src/services/api.test.ts
@@ -56,6 +56,23 @@ describe('addTodo', () => {
     mockFetch.mockResolvedValueOnce({ ok: false, status: 500 });
     await expect(addTodo('Test', TOKEN)).rejects.toThrow('Failed to add todo');
   });
+
+  test('sends custom type in request body', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true, status: 201, json: async () => mockTodo });
+    await addTodo('Test', TOKEN, undefined, 'timeline');
+    expect(mockFetch).toHaveBeenCalledWith('http://127.0.0.1:8000/todos', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...AUTH_HEADER },
+      body: JSON.stringify({ title: 'Test', type: 'timeline' }),
+    });
+  });
+
+  test('calls onUnauthorized and throws on 401', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 401 });
+    const onUnauthorized = jest.fn();
+    await expect(addTodo('Test', TOKEN, onUnauthorized)).rejects.toThrow('Failed to add todo');
+    expect(onUnauthorized).toHaveBeenCalled();
+  });
 });
 
 describe('updateTodo', () => {

--- a/frontend/src/services/api.test.ts
+++ b/frontend/src/services/api.test.ts
@@ -47,7 +47,7 @@ describe('addTodo', () => {
     expect(mockFetch).toHaveBeenCalledWith('http://127.0.0.1:8000/todos', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', ...AUTH_HEADER },
-      body: JSON.stringify({ title: 'Test' }),
+      body: JSON.stringify({ title: 'Test', type: 'todo' }),
     });
     expect(result).toEqual(mockTodo);
   });

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -20,11 +20,16 @@ export const getTodos = async (token: string, onUnauthorized?: () => void): Prom
   return await response.json();
 };
 
-export const addTodo = async (text: string, token: string, onUnauthorized?: () => void): Promise<Todo> => {
+export const addTodo = async (
+  text: string,
+  token: string,
+  onUnauthorized?: () => void,
+  type: string = 'todo',
+): Promise<Todo> => {
   const response = await fetch(`${API_URL}/todos`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', ...authHeaders(token) },
-    body: JSON.stringify({ title: text }),
+    body: JSON.stringify({ title: text, type }),
   });
   if (response.status === 401) {
     onUnauthorized?.();


### PR DESCRIPTION
## Summary
- Add Playwright TypeScript e2e framework in `/e2e` with Page Object Model structure
- Add `docker-compose.e2e.yml` with isolated PostgreSQL volume for reproducible test runs
- Fix app bugs: forward `type` from `TodoForm` → `App` → `api.addTodo`, persist token in `sessionStorage` for auth state capture
- Add GitHub Actions workflow running smoke tests on PRs, full suite on pushes to `main` and nightly

## Test Plan
- [ ] `docker compose -f docker-compose.e2e.yml up -d` starts isolated stack
- [ ] `cd e2e && npm ci && npx playwright test` — 12/12 e2e tests pass
- [ ] `cd frontend && CI=true npm test` — 44/44 unit tests pass
- [ ] PRs trigger smoke subset (`--grep @smoke`); pushes to `main` run full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)