### PR TITLE
fix: pre-create reports dir with open permissions before k6 run

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -1,0 +1,51 @@
+name: Performance Tests
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Start perf stack
+        run: docker compose -f performance/docker-compose.perf.yml up -d postgres_perf backend_perf
+
+      - name: Wait for backend to be ready
+        run: |
+          echo "Waiting for backend_perf..."
+          for i in $(seq 1 30); do
+            if docker compose -f performance/docker-compose.perf.yml exec -T backend_perf curl -sf http://localhost:8000/ > /dev/null 2>&1; then
+              echo "Backend ready"
+              break
+            fi
+            echo "Attempt $i/30..."
+            sleep 2
+          done
+
+      - name: Run smoke test
+        run: |
+          docker compose -f performance/docker-compose.perf.yml run --rm \
+            -e CI=true \
+            -e BASE_URL=http://backend_perf:8000 \
+            k6 run /scripts/scenarios/smoke.js \
+            --out json=/reports/smoke-result.json
+
+      - name: Upload smoke report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: perf-smoke-report-${{ github.run_number }}
+          path: performance/reports/
+          retention-days: 30
+
+      - name: Tear down perf stack
+        if: always()
+        run: docker compose -f performance/docker-compose.perf.yml down

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -22,9 +22,13 @@ jobs:
         run: |
           echo "Waiting for backend_perf..."
           for i in $(seq 1 30); do
-            if docker compose -f performance/docker-compose.perf.yml exec -T backend_perf curl -sf http://localhost:8000/ > /dev/null 2>&1; then
-              echo "Backend ready"
+            if curl -sf http://localhost:8001/ > /dev/null 2>&1; then
+              echo "Backend ready after $i attempt(s)"
               break
+            fi
+            if [ "$i" -eq 30 ]; then
+              echo "ERROR: backend_perf did not become ready after 60 seconds"
+              exit 1
             fi
             echo "Attempt $i/30..."
             sleep 2

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -34,6 +34,9 @@ jobs:
             sleep 2
           done
 
+      - name: Prepare reports directory
+        run: mkdir -p performance/reports && chmod 777 performance/reports
+
       - name: Run smoke test
         run: |
           docker compose -f performance/docker-compose.perf.yml run --rm \

--- a/performance/.gitignore
+++ b/performance/.gitignore
@@ -1,0 +1,3 @@
+reports/*.json
+reports/*.html
+reports/*.csv

--- a/performance/README.md
+++ b/performance/README.md
@@ -51,7 +51,6 @@ If you don't prune, repeated runs reuse existing test users (the auth library ha
 
 Reports are written to `performance/reports/` (gitignored).
 - `*.json` — raw k6 metrics (machine-readable)
-- `*.html` — human-readable summary (smoke scenario only)
 
 ## CI
 

--- a/performance/README.md
+++ b/performance/README.md
@@ -1,0 +1,69 @@
+# Performance Testing
+
+k6-based performance testing framework for the Todo API.
+
+## Quick Start
+
+```bash
+# Run smoke test against local Docker perf stack
+./performance/run.sh smoke
+
+# Run load test against local Docker perf stack
+./performance/run.sh load
+
+# Run against a deployed environment
+./performance/run.sh smoke https://staging.example.com
+./performance/run.sh load https://staging.example.com
+```
+
+## Scenarios
+
+| Scenario | VUs | Duration | Purpose |
+|----------|-----|----------|---------|
+| `smoke`  | 1   | 30s      | Sanity check — runs in CI on every PR |
+| `load`   | 1→50→0 | 5min | Baseline normal traffic |
+| `stress` | 1→200→0 | 10min | Find degradation point |
+| `soak`   | 20 steady | 30min | Memory leaks, connection exhaustion |
+| `spike`  | 0→500→0 | 2min | Resilience under sudden burst |
+
+## ⚠️ Resource Warnings
+
+**`stress` and `spike` scenarios require significant resources.**
+Do NOT run them on a developer laptop. Use a server or CI environment with at least 8GB RAM and 4 CPUs.
+
+**`soak` requires `ACCESS_TOKEN_EXPIRE_MINUTES >= 120`** in the target environment.
+The local perf stack (`docker-compose.perf.yml`) sets this automatically. For external targets, verify before running.
+
+## Local Stack Management
+
+```bash
+# Start perf stack manually (leaves it running for multiple test runs)
+docker compose -f performance/docker-compose.perf.yml up -d postgres_perf backend_perf
+
+# Tear down and remove volumes (cleans up test users/data)
+docker compose -f performance/docker-compose.perf.yml down -v
+```
+
+Pruning the volume resets the database. On the next run, test users (`user_perf_*`) will be re-created fresh.
+If you don't prune, repeated runs reuse existing test users (the auth library handles 409 automatically).
+
+## Reports
+
+Reports are written to `performance/reports/` (gitignored).
+- `*.json` — raw k6 metrics (machine-readable)
+- `*.html` — human-readable summary (smoke scenario only)
+
+## CI
+
+The smoke test runs automatically on every PR to `main` and on push to `main`.
+A threshold breach fails the build. Artifacts are retained for 30 days.
+
+## Threshold Reference
+
+| Metric | CI (strict) | Local (relaxed) |
+|--------|------------|-----------------|
+| `http_req_duration p(95)` | < 500ms | < 1000ms |
+| `http_req_failed rate` | < 1% | < 5% |
+| `checks pass rate` | > 99% | > 95% |
+
+Set `CI=true` env var to use strict thresholds locally: `CI=true ./performance/run.sh smoke`

--- a/performance/docker-compose.perf.yml
+++ b/performance/docker-compose.perf.yml
@@ -1,0 +1,49 @@
+services:
+  postgres_perf:
+    image: postgres:13
+    environment:
+      - POSTGRES_USER=user
+      - POSTGRES_PASSWORD=password
+      - POSTGRES_DB=tododb_perf
+    volumes:
+      - postgres_perf_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U user -d tododb_perf"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+  backend_perf:
+    build:
+      context: ../backend
+    ports:
+      - "8001:8000"
+    volumes:
+      - ../backend:/app
+    environment:
+      - PYTHONUNBUFFERED=1
+      - PYTHONPATH=/app
+      - DATABASE_URL=postgresql+asyncpg://user:password@postgres_perf/tododb_perf
+      - SECRET_KEY=perf-test-secret-key-not-for-production
+      - ACCESS_TOKEN_EXPIRE_MINUTES=120
+    depends_on:
+      postgres_perf:
+        condition: service_healthy
+    restart: unless-stopped
+
+  k6:
+    image: grafana/k6:0.54.0
+    volumes:
+      - ./:/scripts
+      - ./reports:/reports
+    environment:
+      - BASE_URL=http://backend_perf:8000
+    command: run /scripts/scenarios/smoke.js --out json=/reports/result.json
+    depends_on:
+      - backend_perf
+    networks:
+      - default
+
+volumes:
+  postgres_perf_data:

--- a/performance/docker-compose.perf.yml
+++ b/performance/docker-compose.perf.yml
@@ -31,7 +31,7 @@ services:
       postgres_perf:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:8000/ || exit 1"]
+      test: ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:8000/')\" || exit 1"]
       interval: 5s
       timeout: 5s
       retries: 10

--- a/performance/docker-compose.perf.yml
+++ b/performance/docker-compose.perf.yml
@@ -30,6 +30,12 @@ services:
     depends_on:
       postgres_perf:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:8000/ || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
     restart: unless-stopped
 
   k6:
@@ -39,9 +45,10 @@ services:
       - ./reports:/reports
     environment:
       - BASE_URL=http://backend_perf:8000
-    command: run /scripts/scenarios/smoke.js --out json=/reports/result.json
+    command: run /scripts/scenarios/smoke.js --out json=/reports/smoke-result.json
     depends_on:
-      - backend_perf
+      backend_perf:
+        condition: service_healthy
     networks:
       - default
 

--- a/performance/lib/auth.js
+++ b/performance/lib/auth.js
@@ -35,6 +35,11 @@ export function getToken(baseUrl) {
     'login: has access_token': (r) => r.json('access_token') !== undefined,
   });
 
+  if (loginRes.status !== 200) {
+    // Login failed — leave token as null so next iteration retries
+    return null;
+  }
+
   token = loginRes.json('access_token');
   return token;
 }

--- a/performance/lib/auth.js
+++ b/performance/lib/auth.js
@@ -1,0 +1,40 @@
+import http from 'k6/http';
+import { check } from 'k6';
+
+// Module-level token cache — one per VU (each VU has its own module scope)
+let token = null;
+
+const PASSWORD = 'PerfTest123!';
+
+export function getToken(baseUrl) {
+  if (token !== null) {
+    return token;
+  }
+
+  const username = `user_perf_${__VU}`;
+
+  // Register — 409 means user already exists from a prior run, that's fine
+  const registerRes = http.post(
+    `${baseUrl}/auth/register`,
+    JSON.stringify({ username, password: PASSWORD }),
+    { headers: { 'Content-Type': 'application/json' } }
+  );
+  check(registerRes, {
+    'register: 201 or 409': (r) => r.status === 201 || r.status === 409,
+  });
+
+  // Login — always required (even after 409 on register)
+  // NOTE: /auth/login requires application/x-www-form-urlencoded (FastAPI OAuth2PasswordRequestForm)
+  const loginRes = http.post(
+    `${baseUrl}/auth/login`,
+    `username=${encodeURIComponent(username)}&password=${encodeURIComponent(PASSWORD)}`,
+    { headers: { 'Content-Type': 'application/x-www-form-urlencoded' } }
+  );
+  check(loginRes, {
+    'login: status 200': (r) => r.status === 200,
+    'login: has access_token': (r) => r.json('access_token') !== undefined,
+  });
+
+  token = loginRes.json('access_token');
+  return token;
+}

--- a/performance/lib/client.js
+++ b/performance/lib/client.js
@@ -1,0 +1,22 @@
+import http from 'k6/http';
+
+export function makeClient(baseUrl, token) {
+  const headers = {
+    'Authorization': `Bearer ${token}`,
+    'Content-Type': 'application/json',
+  };
+
+  return {
+    get: (path) =>
+      http.get(`${baseUrl}${path}`, { headers }),
+
+    post: (path, body) =>
+      http.post(`${baseUrl}${path}`, JSON.stringify(body), { headers }),
+
+    put: (path, body) =>
+      http.put(`${baseUrl}${path}`, JSON.stringify(body), { headers }),
+
+    del: (path) =>
+      http.del(`${baseUrl}${path}`, null, { headers }),
+  };
+}

--- a/performance/lib/client.js
+++ b/performance/lib/client.js
@@ -21,9 +21,15 @@ export function makeClient(baseUrl, token) {
       http.post(`${baseUrl}${path}`, JSON.stringify(body), { headers }),
 
     put: (path, body) =>
-      http.put(`${baseUrl}${path}`, JSON.stringify(body), { headers }),
+      http.put(`${baseUrl}${path}`, JSON.stringify(body), {
+        headers,
+        tags: { name: path.replace(/\/\d+/, '/:id') },
+      }),
 
     del: (path) =>
-      http.del(`${baseUrl}${path}`, null, { headers }),
+      http.del(`${baseUrl}${path}`, null, {
+        headers,
+        tags: { name: path.replace(/\/\d+/, '/:id') },
+      }),
   };
 }

--- a/performance/lib/client.js
+++ b/performance/lib/client.js
@@ -1,6 +1,13 @@
 import http from 'k6/http';
 
 export function makeClient(baseUrl, token) {
+  if (token === null || token === undefined) {
+    // Auth failed for this VU — return a no-op client so scenario can continue
+    // and k6 checks will record failures naturally
+    const noop = () => ({ status: 0, json: () => null });
+    return { get: noop, post: noop, put: noop, del: noop };
+  }
+
   const headers = {
     'Authorization': `Bearer ${token}`,
     'Content-Type': 'application/json',

--- a/performance/lib/data.js
+++ b/performance/lib/data.js
@@ -1,0 +1,7 @@
+export function todoPayload() {
+  // __VU and __ITER are k6 built-ins: VU ID (1-indexed) and iteration (0-indexed)
+  return {
+    title: `perf-todo-vu${__VU}-iter${__ITER}`,
+    type: 'todo',
+  };
+}

--- a/performance/run.sh
+++ b/performance/run.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -e
+
+SCENARIO=${1:-smoke}
+BASE_URL=${2:-""}
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [ -z "$BASE_URL" ]; then
+  # Run against local Docker Compose perf stack
+  echo "Starting perf stack and running scenario: $SCENARIO"
+  docker compose -f "$SCRIPT_DIR/docker-compose.perf.yml" up -d postgres_perf backend_perf
+  docker compose -f "$SCRIPT_DIR/docker-compose.perf.yml" run --rm \
+    -e BASE_URL=http://backend_perf:8000 \
+    k6 run "/scripts/scenarios/${SCENARIO}.js" --out "json=/reports/${SCENARIO}-result.json"
+  EXIT_CODE=$?
+  docker compose -f "$SCRIPT_DIR/docker-compose.perf.yml" stop backend_perf
+  exit $EXIT_CODE
+else
+  # Run k6 directly against provided BASE_URL (staging, prod, etc.)
+  echo "Running scenario: $SCENARIO against $BASE_URL"
+  docker run --rm \
+    -v "$SCRIPT_DIR:/scripts" \
+    -v "$SCRIPT_DIR/reports:/reports" \
+    -e "BASE_URL=$BASE_URL" \
+    grafana/k6:0.54.0 run "/scripts/scenarios/${SCENARIO}.js" --out "json=/reports/${SCENARIO}-result.json"
+fi

--- a/performance/run.sh
+++ b/performance/run.sh
@@ -9,18 +9,24 @@ if [ -z "$BASE_URL" ]; then
   # Run against local Docker Compose perf stack
   echo "Starting perf stack and running scenario: $SCENARIO"
   docker compose -f "$SCRIPT_DIR/docker-compose.perf.yml" up -d postgres_perf backend_perf
+  set +e
   docker compose -f "$SCRIPT_DIR/docker-compose.perf.yml" run --rm \
     -e BASE_URL=http://backend_perf:8000 \
     k6 run "/scripts/scenarios/${SCENARIO}.js" --out "json=/reports/${SCENARIO}-result.json"
   EXIT_CODE=$?
+  set -e
   docker compose -f "$SCRIPT_DIR/docker-compose.perf.yml" stop backend_perf
   exit $EXIT_CODE
 else
   # Run k6 directly against provided BASE_URL (staging, prod, etc.)
   echo "Running scenario: $SCENARIO against $BASE_URL"
+  set +e
   docker run --rm \
     -v "$SCRIPT_DIR:/scripts" \
     -v "$SCRIPT_DIR/reports:/reports" \
     -e "BASE_URL=$BASE_URL" \
     grafana/k6:0.54.0 run "/scripts/scenarios/${SCENARIO}.js" --out "json=/reports/${SCENARIO}-result.json"
+  EXIT_CODE=$?
+  set -e
+  exit $EXIT_CODE
 fi

--- a/performance/scenarios/load.js
+++ b/performance/scenarios/load.js
@@ -1,0 +1,47 @@
+import { check } from 'k6';
+import { getToken } from '../lib/auth.js';
+import { makeClient } from '../lib/client.js';
+import { todoPayload } from '../lib/data.js';
+
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:8000';
+const IS_CI = !!__ENV.CI;
+
+export const options = {
+  stages: [
+    { duration: '1m', target: 50 },
+    { duration: '3m', target: 50 },
+    { duration: '1m', target: 0 },
+  ],
+  thresholds: {
+    http_req_duration: [IS_CI ? 'p(95)<500' : 'p(95)<1000'],
+    http_req_failed:   [IS_CI ? 'rate<0.01' : 'rate<0.05'],
+    checks:            [IS_CI ? 'rate>0.99' : 'rate>0.95'],
+  },
+};
+
+export default function () {
+  const token = getToken(BASE_URL);
+  const client = makeClient(BASE_URL, token);
+  const payload = todoPayload();
+
+  const listRes = client.get('/todos');
+  check(listRes, { 'GET /todos: 200': (r) => r.status === 200 });
+
+  const createRes = client.post('/todos', payload);
+  check(createRes, {
+    'POST /todos: 201': (r) => r.status === 201,
+    'POST /todos: has id': (r) => r.json('id') !== undefined,
+  });
+
+  if (createRes.status !== 201) {
+    return;
+  }
+
+  const todoId = createRes.json('id');
+
+  const updateRes = client.put(`/todos/${todoId}`, { completed: true });
+  check(updateRes, { 'PUT /todos/{id}: 200': (r) => r.status === 200 });
+
+  const deleteRes = client.del(`/todos/${todoId}`);
+  check(deleteRes, { 'DELETE /todos/{id}: 204': (r) => r.status === 204 });
+}

--- a/performance/scenarios/smoke.js
+++ b/performance/scenarios/smoke.js
@@ -39,6 +39,10 @@ export default function () {
     'POST /todos: completed is false': (r) => r.json('completed') === false,
   });
 
+  if (createRes.status !== 201) {
+    return;
+  }
+
   const todoId = createRes.json('id');
 
   // PUT /todos/{id}
@@ -46,6 +50,7 @@ export default function () {
   check(updateRes, {
     'PUT /todos/{id}: status 200': (r) => r.status === 200,
     'PUT /todos/{id}: completed is true': (r) => r.json('completed') === true,
+    'PUT /todos/{id}: title updated': (r) => r.json('title') === `${payload.title}-updated`,
   });
 
   // DELETE /todos/{id}

--- a/performance/scenarios/smoke.js
+++ b/performance/scenarios/smoke.js
@@ -1,5 +1,4 @@
 import { check } from 'k6';
-import { htmlReport } from 'https://raw.githubusercontent.com/grafana/k6-reporter/main/dist/bundle.js';
 import { textSummary } from 'https://jslib.k6.io/k6-summary/0.0.1/index.js';
 import { getToken } from '../lib/auth.js';
 import { makeClient } from '../lib/client.js';
@@ -62,7 +61,6 @@ export default function () {
 
 export function handleSummary(data) {
   return {
-    'reports/smoke-summary.html': htmlReport(data),
     stdout: textSummary(data, { indent: ' ', enableColors: true }),
   };
 }

--- a/performance/scenarios/smoke.js
+++ b/performance/scenarios/smoke.js
@@ -1,0 +1,63 @@
+import { check } from 'k6';
+import { htmlReport } from 'https://raw.githubusercontent.com/grafana/k6-reporter/main/dist/bundle.js';
+import { textSummary } from 'https://jslib.k6.io/k6-summary/0.0.1/index.js';
+import { getToken } from '../lib/auth.js';
+import { makeClient } from '../lib/client.js';
+import { todoPayload } from '../lib/data.js';
+
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:8000';
+const IS_CI = !!__ENV.CI;
+
+export const options = {
+  vus: 1,
+  duration: '30s',
+  thresholds: {
+    http_req_duration: [IS_CI ? 'p(95)<500' : 'p(95)<1000'],
+    http_req_failed:   [IS_CI ? 'rate<0.01' : 'rate<0.05'],
+    checks:            [IS_CI ? 'rate>0.99' : 'rate>0.95'],
+  },
+};
+
+export default function () {
+  const token = getToken(BASE_URL);
+  const client = makeClient(BASE_URL, token);
+
+  // GET /todos
+  const listRes = client.get('/todos');
+  check(listRes, {
+    'GET /todos: status 200': (r) => r.status === 200,
+    'GET /todos: returns array': (r) => Array.isArray(r.json()),
+  });
+
+  // POST /todos
+  const payload = todoPayload();
+  const createRes = client.post('/todos', payload);
+  check(createRes, {
+    'POST /todos: status 201': (r) => r.status === 201,
+    'POST /todos: has id': (r) => r.json('id') !== undefined,
+    'POST /todos: title matches': (r) => r.json('title') === payload.title,
+    'POST /todos: completed is false': (r) => r.json('completed') === false,
+  });
+
+  const todoId = createRes.json('id');
+
+  // PUT /todos/{id}
+  const updateRes = client.put(`/todos/${todoId}`, { title: `${payload.title}-updated`, completed: true });
+  check(updateRes, {
+    'PUT /todos/{id}: status 200': (r) => r.status === 200,
+    'PUT /todos/{id}: completed is true': (r) => r.json('completed') === true,
+  });
+
+  // DELETE /todos/{id}
+  const deleteRes = client.del(`/todos/${todoId}`);
+  check(deleteRes, {
+    'DELETE /todos/{id}: status 204': (r) => r.status === 204,
+  });
+}
+
+export function handleSummary(data) {
+  return {
+    'reports/smoke-summary.html': htmlReport(data),
+    stdout: textSummary(data, { indent: ' ', enableColors: true }),
+  };
+}

--- a/performance/scenarios/soak.js
+++ b/performance/scenarios/soak.js
@@ -35,6 +35,7 @@ export default function () {
     return;
   }
 
+  // PUT omitted intentionally — soak tests reads/writes only to reduce write amplification over 30 minutes
   const todoId = createRes.json('id');
 
   const deleteRes = client.del(`/todos/${todoId}`);

--- a/performance/scenarios/soak.js
+++ b/performance/scenarios/soak.js
@@ -1,0 +1,42 @@
+import { check } from 'k6';
+import { getToken } from '../lib/auth.js';
+import { makeClient } from '../lib/client.js';
+import { todoPayload } from '../lib/data.js';
+
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:8000';
+
+// NOTE: Requires ACCESS_TOKEN_EXPIRE_MINUTES >= 120 in the target environment.
+// docker-compose.perf.yml sets this to 120. For external targets, verify before running.
+export const options = {
+  vus: 20,
+  duration: '30m',
+  thresholds: {
+    http_req_duration: ['p(95)<1000'],
+    http_req_failed:   ['rate<0.01'],
+    checks:            ['rate>0.99'],
+  },
+};
+
+export default function () {
+  const token = getToken(BASE_URL);
+  const client = makeClient(BASE_URL, token);
+  const payload = todoPayload();
+
+  const listRes = client.get('/todos');
+  check(listRes, { 'GET /todos: 200': (r) => r.status === 200 });
+
+  const createRes = client.post('/todos', payload);
+  check(createRes, {
+    'POST /todos: 201': (r) => r.status === 201,
+    'POST /todos: has id': (r) => r.json('id') !== undefined,
+  });
+
+  if (createRes.status !== 201) {
+    return;
+  }
+
+  const todoId = createRes.json('id');
+
+  const deleteRes = client.del(`/todos/${todoId}`);
+  check(deleteRes, { 'DELETE /todos/{id}: 204': (r) => r.status === 204 });
+}

--- a/performance/scenarios/spike.js
+++ b/performance/scenarios/spike.js
@@ -1,0 +1,38 @@
+import { check } from 'k6';
+import { getToken } from '../lib/auth.js';
+import { makeClient } from '../lib/client.js';
+import { todoPayload } from '../lib/data.js';
+
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:8000';
+
+// WARNING: This scenario targets 500 VUs. Do NOT run on a developer laptop.
+// Use a server or CI environment with at least 8GB RAM and 4 CPUs.
+export const options = {
+  stages: [
+    { duration: '10s', target: 0 },
+    { duration: '20s', target: 500 },
+    { duration: '1m', target: 500 },
+    { duration: '30s', target: 0 },
+  ],
+  thresholds: {
+    http_req_failed: ['rate<0.20'],
+    checks:          ['rate>0.80'],
+  },
+};
+
+export default function () {
+  const token = getToken(BASE_URL);
+  const client = makeClient(BASE_URL, token);
+  const payload = todoPayload();
+
+  const listRes = client.get('/todos');
+  check(listRes, { 'GET /todos: 200 or 503': (r) => r.status === 200 || r.status === 503 });
+
+  const createRes = client.post('/todos', payload);
+  check(createRes, { 'POST /todos: 201 or 5xx': (r) => r.status === 201 || r.status >= 500 });
+
+  if (createRes.status === 201) {
+    const todoId = createRes.json('id');
+    client.del(`/todos/${todoId}`);
+  }
+}

--- a/performance/scenarios/spike.js
+++ b/performance/scenarios/spike.js
@@ -33,6 +33,6 @@ export default function () {
 
   if (createRes.status === 201) {
     const todoId = createRes.json('id');
-    client.del(`/todos/${todoId}`);
+    client.del(`/todos/${todoId}`); // cleanup is best-effort during spike; result not checked
   }
 }

--- a/performance/scenarios/stress.js
+++ b/performance/scenarios/stress.js
@@ -18,6 +18,7 @@ export const options = {
     http_req_failed:   ['rate<0.10'],
     checks:            ['rate>0.90'],
   },
+  // http_req_failed and checks are fixed — stress thresholds are intentionally lenient regardless of CI
 };
 
 export default function () {

--- a/performance/scenarios/stress.js
+++ b/performance/scenarios/stress.js
@@ -1,0 +1,48 @@
+import { check } from 'k6';
+import { getToken } from '../lib/auth.js';
+import { makeClient } from '../lib/client.js';
+import { todoPayload } from '../lib/data.js';
+
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:8000';
+const IS_CI = !!__ENV.CI;
+
+export const options = {
+  stages: [
+    { duration: '2m', target: 50 },
+    { duration: '3m', target: 100 },
+    { duration: '3m', target: 200 },
+    { duration: '2m', target: 0 },
+  ],
+  thresholds: {
+    http_req_duration: [IS_CI ? 'p(95)<500' : 'p(95)<2000'],
+    http_req_failed:   ['rate<0.10'],
+    checks:            ['rate>0.90'],
+  },
+};
+
+export default function () {
+  const token = getToken(BASE_URL);
+  const client = makeClient(BASE_URL, token);
+  const payload = todoPayload();
+
+  const listRes = client.get('/todos');
+  check(listRes, { 'GET /todos: 200': (r) => r.status === 200 });
+
+  const createRes = client.post('/todos', payload);
+  check(createRes, {
+    'POST /todos: 201': (r) => r.status === 201,
+    'POST /todos: has id': (r) => r.json('id') !== undefined,
+  });
+
+  if (createRes.status !== 201) {
+    return;
+  }
+
+  const todoId = createRes.json('id');
+
+  const updateRes = client.put(`/todos/${todoId}`, { completed: true });
+  check(updateRes, { 'PUT /todos/{id}: 200': (r) => r.status === 200 });
+
+  const deleteRes = client.del(`/todos/${todoId}`);
+  check(deleteRes, { 'DELETE /todos/{id}: 204': (r) => r.status === 204 });
+}


### PR DESCRIPTION
## Summary
- k6 runs as non-root and cannot write to `/reports` when Docker auto-creates the host-side mount directory as root
- Added a step to `mkdir -p performance/reports && chmod 777 performance/reports` before the k6 run so the directory is writable

## Root cause
`performance/reports/` is mounted as a Docker volume. When Docker creates the host directory it's owned by root. k6 (non-root user) fails at init with `permission denied` on `smoke-result.json` before any VUs run — exit code 255.

## Test plan
- [ ] Performance Tests CI workflow passes (smoke job)
- [ ] `perf-smoke-report-*` artifact is uploaded successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)